### PR TITLE
Remove unnecessary execution stack extraction in step decorators

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     description='BDD for pytest',
     author='Oleg Pidsadnyi',
     author_email='oleg.podsadny@gmail.com',
-    version='0.4',
+    version='0.4.1',
     cmdclass={'test': PyTest},
     install_requires=[
         'pytest',


### PR DESCRIPTION
This patch fixes bugs when pytest-xdist is used.
