### PR TITLE
FIx unicode argumented fixture

### DIFF
--- a/pytest_bdd/scenario.py
+++ b/pytest_bdd/scenario.py
@@ -80,11 +80,11 @@ def find_argumented_step_fixture_name(name, fixturemanager, request=None):
     """Find argumented step fixture name."""
     for fixturename, fixturedefs in fixturemanager._arg2fixturedefs.items():
         for fixturedef in fixturedefs:
-            if isinstance(name, unicode):
-                name = name.encode('utf8')
 
             pattern = getattr(fixturedef.func, 'pattern', None)
-            match = pattern.match(name) if pattern else None
+            match = pattern.match(name) if pattern and isinstance(name, str) \
+                else pattern.match(name.encode('utf8')) if pattern and isinstance(name, unicode) \
+                else None
             if match:
                 converters = getattr(fixturedef.func, 'converters', {})
                 for arg, value in match.groupdict().items():


### PR DESCRIPTION
This solves the problem when, as parameterized steps in Unicode, you can send Unicode. 
For example: 
Step: When вводим в поле "Email" данные "Случайно" на странице "Контактные данные"
The code would look like this: @when(re.compile(r'вводим в поле "(?P<field_name>.+)" данные "(?P<input_data>.+)" на странице "(?P<page>.+)"', re.U))
