### PR TITLE
Added hook before the step is executed with evaluated parameters

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+Unreleased
+----------
+
+- Added hook before the step is executed with evaluated parameters (olegpidsadnyi)
+
+
 2.7.2
 -----
 

--- a/README.rst
+++ b/README.rst
@@ -919,6 +919,9 @@ which might be helpful building useful reporting, visualization, etc on top of i
 * pytest_bdd_before_step(request, feature, scenario, step, step_func) - Called before step function
   is executed and it's arguments evaluated
 
+* pytest_bdd_before_step_call(request, feature, scenario, step, step_func, step_func_args) - Called before step
+* function is executed with evaluated arguments
+
 * pytest_bdd_after_step(request, feature, scenario, step, step_func, step_func_args) - Called after step function
   is successfully executed
 

--- a/pytest_bdd/generation.py
+++ b/pytest_bdd/generation.py
@@ -14,7 +14,6 @@ from .scenario import (
 from .feature import get_features
 from .types import STEP_TYPES
 
-tw = py.io.TerminalWriter()
 
 template_lookup = TemplateLookup(directories=[os.path.join(os.path.dirname(__file__), "templates")])
 
@@ -62,6 +61,7 @@ def show_missing_code(config):
 
 def print_missing_code(scenarios, steps):
     """Print missing code with TerminalWriter."""
+    tw = py.io.TerminalWriter()
     scenario = step = None
 
     for scenario in scenarios:
@@ -160,6 +160,7 @@ def group_steps(steps):
 
 def _show_missing_code_main(config, session):
     """Preparing fixture duplicates for output."""
+    tw = py.io.TerminalWriter()
     session.perform_collect()
 
     fm = session._fixturemanager

--- a/pytest_bdd/hooks.py
+++ b/pytest_bdd/hooks.py
@@ -10,6 +10,10 @@ def pytest_bdd_after_scenario(request, feature, scenario):
 
 
 def pytest_bdd_before_step(request, feature, scenario, step, step_func):
+    """Called before step function is set up."""
+
+
+def pytest_bdd_before_step_call(request, feature, scenario, step, step_func, step_func_args):
     """Called before step function is executed."""
 
 

--- a/tests/feature/test_steps.py
+++ b/tests/feature/test_steps.py
@@ -162,6 +162,9 @@ def test_step_hooks(testdir):
     calls = reprec.getcalls("pytest_bdd_before_step")
     assert calls[0].request
 
+    calls = reprec.getcalls("pytest_bdd_before_step_call")
+    assert calls[0].request
+
     calls = reprec.getcalls("pytest_bdd_after_step")
     assert calls[0].request
 
@@ -182,6 +185,9 @@ def test_step_hooks(testdir):
 
     calls = reprec.getcalls("pytest_bdd_before_step")
     assert len(calls) == 2
+
+    calls = reprec.getcalls("pytest_bdd_before_step_call")
+    assert len(calls) == 1
 
     calls = reprec.getcalls("pytest_bdd_step_error")
     assert calls[0].request

--- a/tests/generation/test_generate_missing.py
+++ b/tests/generation/test_generate_missing.py
@@ -6,7 +6,8 @@ import py
 
 
 def test_generate_missing(testdir):
-    tests = testdir.mkpydir("tests")
+    dirname = "test_generate_missing"
+    tests = testdir.mkpydir(dirname)
     with open(os.path.join(os.path.dirname(__file__), "generation.feature")) as fd:
         tests.join('generation.feature').write(fd.read())
 
@@ -30,8 +31,7 @@ def test_generate_missing(testdir):
             pass
     """))
 
-    result = testdir.runpytest(
-        "tests", "--generate-missing", "--feature", tests.join('generation.feature').strpath)
+    result = testdir.runpytest(dirname, "--generate-missing", "--feature", tests.join('generation.feature').strpath)
 
     result.stdout.fnmatch_lines([
         'Scenario "Code is generated for scenarios which are not bound to any tests" is not bound to any test *']


### PR DESCRIPTION
Currently there is a hook similar to pytest item_call is missing. It is called before the step is executed when all the depending fixtures are evaluated.