### PR TITLE
Fix incompatibility with xdist

### DIFF
--- a/pytest_bdd/scenario.py
+++ b/pytest_bdd/scenario.py
@@ -410,7 +410,9 @@ def scenarios(*feature_paths):
     module_scenarios = frozenset(
         (attr.__scenario__.feature.filename, attr.__scenario__.name)
         for name, attr in module.__dict__.items() if hasattr(attr, '__scenario__'))
-    for feature in get_features(abs_feature_paths):
+    feature_list = get_features(abs_feature_paths)
+    feature_list.sort()
+    for feature in feature_list:
         for scenario_name, scenario_object in feature.scenarios.items():
             # skip already bound scenarios
             if (scenario_object.feature.filename, scenario_name) not in module_scenarios:


### PR DESCRIPTION
Apparently xdist needs the test discovery to return a consistently ordered test list from each worker.
The scenarios() helper doesn't always return test in the same order so test discovery fails.

I added a sort in the scenarios function. I'm kinda new to python so I don't know if there's a faster / better / more pythonic way to do it but at least it works  (maybe we can use a sorted list to make things faster ?).