### PR TITLE
Fixes the hook registration since pytest 2.8. Requirement changed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+\.DS_Store
 *.rej
 *.py[cod]
 /.env

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+2.16.0
+------
+
+- Depends on pytest 2.8 and fixes the registration of hooks (olegpidsadnyi)
+
+
 2.15.0
 ------
 

--- a/pytest_bdd/__init__.py
+++ b/pytest_bdd/__init__.py
@@ -3,6 +3,6 @@
 from pytest_bdd.steps import given, when, then
 from pytest_bdd.scenario import scenario, scenarios
 
-__version__ = '2.15.0'
+__version__ = '2.16.0'
 
 __all__ = [given.__name__, when.__name__, then.__name__, scenario.__name__, scenarios.__name__]

--- a/pytest_bdd/plugin.py
+++ b/pytest_bdd/plugin.py
@@ -18,7 +18,7 @@ from .fixtures import *
 def pytest_addhooks(pluginmanager):
     """Register plugin hooks."""
     from pytest_bdd import hooks
-    pluginmanager.addhooks(hooks)
+    pluginmanager.add_hookspecs(hooks)
 
 
 @given('trace')

--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ setup(
         "Mako",
         "parse",
         "parse_type",
-        "pytest>=2.6.0",
+        "pytest>=2.8.0",
         "six>=1.9.0",
     ],
     # the following makes a plugin available to py.test


### PR DESCRIPTION
Method addhooks is deprecated since pytest2.8.
Why don't we just increase the version number to 2.16.0 with py.test 2.8 as a requirement.
Changing addhooks to add_hookspecs seems to help.