### PR TITLE
Avoid deprecation warnings on pytest 2.8

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -12,6 +12,7 @@ These people have contributed to `pytest-bdd`, in alphabetical order:
 * `Andrey Makhnach <andrey.makhnach@gmail.com>`_
 * `Aron Curzon <curzona@gmail.com>`_
 * `Dmitrijs Milajevs <dimazest@gmail.com>`_
+* `Florian Bruhin <me@the-compiler.org>`_
 * `Floris Bruynooghe <flub@devork.be>`_
 * `Harro van der Klauw <hvdklauw@gmail.com>`_
 * `Laurence Rowe <l@lrowe.co.uk>`_

--- a/pytest_bdd/plugin.py
+++ b/pytest_bdd/plugin.py
@@ -18,7 +18,12 @@ from .fixtures import *
 def pytest_addhooks(pluginmanager):
     """Register plugin hooks."""
     from pytest_bdd import hooks
-    pluginmanager.addhooks(hooks)
+    try:
+        # pytest >= 2.8
+        pluginmanager.add_hookspecs(hooks)
+    except AttributeError:
+        # pytest < 2.8
+        pluginmanager.addhooks(hooks)
 
 
 @given('trace')

--- a/pytest_bdd/reporting.py
+++ b/pytest_bdd/reporting.py
@@ -145,9 +145,11 @@ class ScenarioReport(object):
             self.add_step_report(report)
 
 
-def pytest_runtest_makereport(item, call, __multicall__):
+@pytest.mark.hookwrapper
+def pytest_runtest_makereport(item, call):
     """Store item in the report object."""
-    rep = __multicall__.execute()
+    outcome = yield
+    rep = outcome.get_result()
     try:
         scenario_report = item.__scenario_report__
     except AttributeError:
@@ -155,7 +157,6 @@ def pytest_runtest_makereport(item, call, __multicall__):
     else:
         rep.scenario = scenario_report.serialize()
         rep.item = {"name": item.name}
-    return rep
 
 
 @pytest.mark.tryfirst


### PR DESCRIPTION
Fixes #154.

After this, pytest-bdd is still compatible with pytest 2.7, I didn't check with earlier versions.