### PR TITLE
Disable xdist tests for now.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ env:
   matrix:
     - TESTENV=linters
     - TESTENV=py27
-    - TESTENV=py27-xdist
+#    - TESTENV=py27-xdist
     - TESTENV=py27-pytest-latest
     - TESTENV=py34
     - TESTENV=coveralls

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [tox]
 distshare={homedir}/.tox/distshare
-envlist=linters,py27,py27-xdist,py27-pytest-latest,py34
+#envlist=linters,py27,py27-xdist,py27-pytest-latest,py34
+envlist=linters,py27,py27-pytest-latest,py34
 skip_missing_interpreters = true
 
 [testenv]
@@ -11,11 +12,11 @@ deps = -r{toxinidir}/requirements-testing.txt
 interpreter=python2.7
 commands={[testenv]commands} pytest_bdd --pep8
 
-[testenv:py27-xdist]
-basepython=python2.7
-commands=
-  py.test pytest_bdd tests -n3 --pep8 -rfsxX \
-        --junitxml={envlogdir}/junit-{envname}.xml
+#[testenv:py27-xdist]
+#basepython=python2.7
+#commands=
+#  py.test pytest_bdd tests -n3 --pep8 -rfsxX \
+#        --junitxml={envlogdir}/junit-{envname}.xml
 
 [testenv:py27-pytest-latest]
 basepython=python2.7


### PR DESCRIPTION
See #162.
Those can probably be re-enabled when pytest 2.9 is released, but for now let's
disable them to have useful Travis feedback.