### PR TITLE
Add support for data tables

### DIFF
--- a/pytest_bdd/feature.py
+++ b/pytest_bdd/feature.py
@@ -1,9 +1,7 @@
 """Feature.
 
 The way of describing the behavior is based on Gherkin language, but a very
-limited version. It doesn't support any parameter tables.
-If the parametrization is needed to generate more test cases it can be done
-on the fixture level of the pytest.
+limited version.
 The <variable> syntax can be used here to make a connection between steps and
 it will also validate the parameters mentioned in the steps with ones
 provided in the pytest parametrization table.
@@ -19,8 +17,6 @@ Syntax example:
         And the article should be published  # Note: will query the database
 
 :note: The "#" symbol is used for comments.
-:note: There're no multiline steps, the description of the step must fit in
-one line.
 """
 
 from collections import OrderedDict
@@ -163,15 +159,35 @@ def get_features(paths, **kwargs):
     return features
 
 
-class Examples(object):
+def is_table_line(line):
+    """Detect table line.
 
-    """Example table."""
+    :param `string` line: the line to inspect
+
+    :return: `bool`.
+    """
+    return line.startswith('|') and line.endswith('|')
+
+
+def parse_table_line(line):
+    """Parse cells contained in a table line.
+
+    :param `string` line: the line to parse (stripped)
+
+    :return: `string list`.
+    """
+    return [l.strip() for l in line.split("|")[1:-1]]
+
+
+class Table(object):
+
+    """Example or data table."""
 
     def __init__(self):
-        """Initialize examples instance."""
-        self.example_params = []
-        self.examples = []
-        self.vertical_examples = []
+        """Initialize table instance."""
+        self.params = []
+        self.entries = []
+        self.vertical_entries = []
         self.line_number = None
         self.name = None
 
@@ -180,64 +196,80 @@ class Examples(object):
 
         :param names: `list` of `string` parameter names.
         """
-        self.example_params = [str(key) for key in keys]
+        self.params = [str(key) for key in keys]
 
-    def add_example(self, values):
-        """Add example.
+    def add_row(self, values):
+        """Add a table row from a line in horizontal mode.
 
         :param values: `list` of `string` parameter values.
         """
-        self.examples.append(values)
+        self.entries.append(values)
 
-    def add_example_row(self, param, values):
-        """Add example row.
+    def add_col(self, param, values):
+        """Add a table column from a line in vertical mode.
 
         :param param: `str` parameter name
         :param values: `list` of `string` parameter values
         """
-        if param in self.example_params:
+        if param in self.params:
             raise exceptions.ExamplesNotValidError(
                 """Example rows should contain unique parameters. "{0}" appeared more than once""".format(
                     param,
                 )
             )
-        self.example_params.append(param)
-        self.vertical_examples.append(values)
+        self.params.append(param)
+        self.vertical_entries.append(values)
 
     def get_params(self, converters, builtin=False):
         """Get scenario pytest parametrization table.
 
         :param converters: `dict` of converter functions to convert parameter values
         """
-        param_count = len(self.example_params)
-        if self.vertical_examples and not self.examples:
-            for value_index in range(len(self.vertical_examples[0])):
-                example = []
+        param_count = len(self.params)
+        if self.vertical_entries and not self.entries:
+            for value_index in range(len(self.vertical_entries[0])):
+                entry = []
                 for param_index in range(param_count):
-                    example.append(self.vertical_examples[param_index][value_index])
-                self.examples.append(example)
+                    entry.append(self.vertical_entries[param_index][value_index])
+                self.entries.append(entry)
 
-        if self.examples:
+        if self.entries:
             params = []
-            for example in self.examples:
-                example = list(example)
-                for index, param in enumerate(self.example_params):
-                    raw_value = example[index]
+            for entry in self.entries:
+                entry = list(entry)
+                for index, param in enumerate(self.params):
+                    raw_value = entry[index]
                     if converters and param in converters:
                         value = converters[param](raw_value)
                         if not builtin or value.__class__.__module__ in {'__builtin__', 'builtins'}:
-                            example[index] = value
-                params.append(example)
-            return [self.example_params, params]
+                            entry[index] = value
+                params.append(entry)
+            return [self.params, params]
         else:
             return []
 
     def __bool__(self):
         """Bool comparison."""
-        return bool(self.vertical_examples or self.examples)
+        return bool(self.vertical_entries or self.entries)
 
     if six.PY2:
         __nonzero__ = __bool__
+
+
+class Examples(Table):
+    """Examples table
+    Used for Gherkin test parametrization of tests.
+    This is the same class as Table but with different name for easier
+    interactive debugging.
+    """
+
+
+class DataTable(Table):
+    """Data table
+    Used to provide fixture injection for steps.
+    This is the same class as Table but with different name for easier
+    interactive debugging.
+    """
 
 
 class Feature(object):
@@ -273,17 +305,28 @@ class Feature(object):
             content = force_unicode(f.read(), encoding)
             for line_number, line in enumerate(content.splitlines(), start=1):
                 unindented_line = line.lstrip()
+                stripped_line = line.strip()
+                clean_line = strip_comments(line)
                 line_indent = len(line) - len(unindented_line)
                 if step and (step.indent < line_indent or ((not unindented_line) and multiline_step)):
-                    multiline_step = True
-                    # multiline step, so just add line and continue
-                    step.add_line(line)
+                    if is_table_line(stripped_line):
+                        # This line is part of a data table attached to the
+                        # current step
+                        if step.datatable.params:
+                            # We already met the headers row
+                            step.datatable.add_row(
+                                    parse_table_line(stripped_line))
+                        else:
+                            step.datatable.set_param_names(
+                                    parse_table_line(stripped_line))
+                    else:
+                        multiline_step = True
+                        # multiline step, so just add line and continue
+                        step.add_line(line)
                     continue
                 else:
                     step = None
                     multiline_step = False
-                stripped_line = line.strip()
-                clean_line = strip_comments(line)
                 if not clean_line and (not prev_mode or prev_mode not in types.FEATURE):
                     continue
                 mode = get_step_type(clean_line) or mode
@@ -344,14 +387,14 @@ class Feature(object):
                     (scenario or self).examples.line_number = line_number
                 elif mode == types.EXAMPLES_HEADERS:
                     (scenario or self).examples.set_param_names(
-                        [l.strip() for l in parsed_line.split("|")[1:-1] if l.strip()])
+                            parse_table_line(parsed_line))
                     mode = types.EXAMPLE_LINE
                 elif mode == types.EXAMPLE_LINE:
-                    (scenario or self).examples.add_example([l.strip() for l in stripped_line.split("|")[1:-1]])
+                    (scenario or self).examples.add_row(parse_table_line(stripped_line))
                 elif mode == types.EXAMPLE_LINE_VERTICAL:
-                    param_line_parts = [l.strip() for l in stripped_line.split("|")[1:-1]]
+                    param_line_parts = parse_table_line(stripped_line)
                     try:
-                        (scenario or self).examples.add_example_row(param_line_parts[0], param_line_parts[1:])
+                        (scenario or self).examples.add_col(param_line_parts[0], param_line_parts[1:])
                     except exceptions.ExamplesNotValidError as exc:
                         if scenario:
                             raise exceptions.FeatureError(
@@ -456,7 +499,7 @@ class Scenario(object):
 
     def get_example_params(self):
         """Get example parameter names."""
-        return set(self.examples.example_params + self.feature.examples.example_params)
+        return set(self.examples.params + self.feature.examples.params)
 
     def get_params(self, builtin=False):
         """Get converted example params."""
@@ -504,6 +547,7 @@ class Step(object):
         self.stop = 0
         self.scenario = None
         self.background = None
+        self.datatable = DataTable()
 
     def add_line(self, line):
         """Add line to the multiple step.

--- a/pytest_bdd/scenario.py
+++ b/pytest_bdd/scenario.py
@@ -192,6 +192,11 @@ def _execute_scenario(feature, scenario, request, encoding):
                 )
                 raise
 
+            if step.datatable:
+                inject_fixture(
+                        request,
+                        'datatable',
+                        [step.datatable.params, step.datatable.entries])
             _execute_step_function(request, scenario, step, step_func)
     finally:
         request.config.hook.pytest_bdd_after_scenario(

--- a/pytest_bdd/steps.py
+++ b/pytest_bdd/steps.py
@@ -72,7 +72,7 @@ def given(name, fixture=None, converters=None, scope='function', target_fixture=
     :param fixture: Optional name of the fixture to reuse.
     :param converters: Optional `dict` of the argument or parameter converters in form
                        {<param_name>: <converter function>}.
-    :scope: Optional fixture scope
+    :param scope: Optional fixture scope
     :param target_fixture: Target fixture name to replace by steps definition function
     :raises: StepError in case of wrong configuration.
     :note: Can't be used as a decorator when the fixture is specified.

--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,7 @@ setup(
             "pytest-bdd = pytest_bdd.scripts:main",
         ]
     },
-    tests_require=["tox"],
+    tests_require=["tox", "mock", "execnet"],
     packages=["pytest_bdd"],
     include_package_data=True,
 )

--- a/tests/feature/test_datatable.feature
+++ b/tests/feature/test_datatable.feature
@@ -1,0 +1,13 @@
+Feature: Datatables
+
+  Scenario Outline: I use datatables
+    Given the following users exist:
+      | name   | email              | twitter         |
+      | Aslak  | aslak@cucumber.io  | @aslak_hellesoy |
+      | Julien | julien@cucumber.io | @jbpros         |
+      | Matt   | matt@cucumber.io   | @mattwynne      |
+    Then I should see the following names:
+      | name   |
+      | Aslak  |
+      | Julien |
+      | Matt   |

--- a/tests/feature/test_datatable.py
+++ b/tests/feature/test_datatable.py
@@ -1,0 +1,24 @@
+"""Datatables feature tests."""
+
+from pytest_bdd import (
+    given,
+    scenario,
+    then,
+)
+
+
+@scenario('test_datatable.feature', 'I use datatables')
+def test_i_use_datatables():
+    """I use datatables."""
+
+
+@given('the following users exist:')
+def the_following_users_exist(datatable):
+    """the following users exist:."""
+    return datatable[1]
+
+
+@then('I should see the following names:')
+def i_should_see(datatable, the_following_users_exist):
+    names = [row[0] for row in the_following_users_exist]
+    assert names == sum(datatable[1], [])


### PR DESCRIPTION
Fixes #150 and helps mitigating the effects of #157 

The goal is to allow data tables attached to steps as described in https://cucumber.io/docs/reference#data-tables. This has nothing to do with example tables, it does not trigger multiple run of the scenario. An artificial example would be:

```
Feature: Datatables

  Scenario Outline: I use datatables
    Given the following users exist:
      | name   | email              | twitter         |
      | Aslak  | aslak@cucumber.io  | @aslak_hellesoy |
      | Julien | julien@cucumber.io | @jbpros         |
      | Matt   | matt@cucumber.io   | @mattwynne      |
    Then I should see the following names:
      | name   |
      | Aslak  |
      | Julien |
      | Matt   |
```

For each step which has a data table, the implementation can use a datatable argument which is a list of two lists: the list of headers and the list of rows. 

```
@given('the following users exist:')
def the_following_users_exist(datatable):
    """the following users exist:."""
    return datatable[1]

@then('I should see the following names:')
def i_should_see(datatable, the_following_users_exist):
    names = [row[0] for row in the_following_users_exist]
    assert names == sum(datatable[1], [])

```
## Implementation

Commits should be reviewed one by one, otherwise things will be cluttered. Note that all commits are fully toxed.
- 9f744fd performs clean up that have nothing to do with the issues.  It should probably be merged in any case.
- 8461566 is preparatory. Since a data table very much looks like an example table I factored out a generic class `Table`.  Not much happens here, only renaming and trivial subclassing (I chose to keep the class `Examples` for clarity and debugging purposes, although it inherits absolutely everything from `Table`).
- 0b14878 implements the feature parsing part. Datatables are sort of multi-line steps so they are parsed at the same point in the file. I also introduced two helper functions `is_table_line` and `parse_table_line`.
- 454a01a is where I could easily be totally wrong. Fixture injection is deep into python dark magic and totally out of my comfort zone. Still I tried to figure out how to pass the data tables to steps implementations
- 67fffa1 adds some minimal test for this new feature (in case of merge we should probably add more)
- 7e7e9a7 is because I missed one  `git commit --amend` before pushing...

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pytest-dev/pytest-bdd/180)

<!-- Reviewable:end -->
