### PR TITLE
Fix typos in Feature examples section

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -558,7 +558,7 @@ Feature examples
 It's possible to declare example table once for the whole feature, and it will be shared
 among all the scenarios of that feature:
 
-..code-block:: gherkin
+.. code-block:: gherkin
 
     Feature: Outline
 
@@ -581,7 +581,8 @@ For some more complex case, you might want to parametrize on both levels: featur
 This is allowed as long as parameter names do not clash:
 
 
-..code-block:: gherkin
+.. code-block:: gherkin
+
     Feature: Outline
 
         Examples:


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pytest-dev/pytest-bdd/181)
<!-- Reviewable:end -->
