### PR TITLE
tox: Switch pytest-latest env from hg to git

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,7 @@ basepython=python2.7
 deps =
     {[testenv]deps}
     hg+https://bitbucket.org/pytest-dev/py#egg=py
-    hg+https://bitbucket.org/pytest-dev/pytest#egg=pytest
+    git+https://github.com/pytest-dev/pytest.git@features#egg=pytest
 
 [testenv:coveralls]
 passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH


### PR DESCRIPTION
pytest switched from Bitbucket to GitHub some while ago. This also uses the
`features` branch as that's the one with the newest breaking changes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pytest-dev/pytest-bdd/182)
<!-- Reviewable:end -->
