### PR TITLE
Fix FixtureDef signature for newer pytest versions

### DIFF
--- a/pytest_bdd/steps.py
+++ b/pytest_bdd/steps.py
@@ -284,15 +284,19 @@ def inject_fixture(request, arg, value):
     :param arg: argument name
     :param value: argument value
     """
-    fd = python.FixtureDef(
-        fixturemanager=request._fixturemanager,
-        baseid=None,
-        argname=arg,
-        func=lambda: value,
-        scope="function",
-        params=None,
-        yieldctx=False,
-    )
+    fd_kwargs = {
+        'fixturemanager': request._fixturemanager,
+        'baseid': None,
+        'argname': arg,
+        'func': lambda: value,
+        'scope': "function",
+        'params': None,
+    }
+
+    if 'yieldctx' in get_args(python.FixtureDef.__init__):
+        fd_kwargs['yieldctx'] = False
+
+    fd = python.FixtureDef(**fd_kwargs)
     fd.cached_result = (value, 0, None)
 
     old_fd = getattr(request, "_fixturedefs", {}).get(arg)

--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,7 @@ basepython=python2.7
 deps =
     {[testenv]deps}
     hg+https://bitbucket.org/pytest-dev/py#egg=py
-    hg+https://bitbucket.org/pytest-dev/pytest#egg=pytest
+    git+https://github.com/pytest-dev/pytest.git@features#egg=pytest
 
 [testenv:coveralls]
 passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH


### PR DESCRIPTION
**(please merge this after #182)**

In pytest-dev/pytest#1586 the "yieldctx"
argument to FixtureDef was removed.

This uses utils.get_args to check if it's needed or not so pytest-bdd
works on pytest versions before and after that PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pytest-dev/pytest-bdd/183)
<!-- Reviewable:end -->
