### PR TITLE
Better error explanation for the steps defined outside of scenarios

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+2.16.2
+------
+
+- Fix FixtureDef signature for newer pytest versions (The-Compiler)
+- Better error explanation for the steps defined outside of scenarios (olegpidsadnyi)
+
 
 2.16.1
 ------

--- a/pytest_bdd/__init__.py
+++ b/pytest_bdd/__init__.py
@@ -3,6 +3,6 @@
 from pytest_bdd.steps import given, when, then
 from pytest_bdd.scenario import scenario, scenarios
 
-__version__ = '2.16.1'
+__version__ = '2.16.2'
 
 __all__ = [given.__name__, when.__name__, then.__name__, scenario.__name__, scenarios.__name__]

--- a/pytest_bdd/feature.py
+++ b/pytest_bdd/feature.py
@@ -287,6 +287,10 @@ class Feature(object):
                     continue
                 mode = get_step_type(clean_line) or mode
 
+                if not scenario and prev_mode not in (types.BACKGROUND, types.GIVEN) and mode in types.STEP_TYPES:
+                    raise exceptions.FeatureError(
+                        "Step definition outside of a Scenario or a Background", line_number, clean_line, filename)
+
                 if strict_gherkin:
                     if (self.background and not scenario and mode not in (
                             types.SCENARIO, types.SCENARIO_OUTLINE, types.GIVEN, types.TAG)):

--- a/tests/feature/test_no_scenario.py
+++ b/tests/feature/test_no_scenario.py
@@ -1,0 +1,26 @@
+"""Test no scenarios defined in the feature file."""
+
+import py
+import textwrap
+
+
+def test_no_scenarios(testdir):
+    """Test no scenarios defined in the feature file."""
+    features = testdir.mkdir('features')
+    features.join('test.feature').write_text(textwrap.dedent(u"""
+        Given foo
+        When bar
+        Then baz
+    """), 'utf-8', ensure=True)
+    testdir.makepyfile(py.code.Source("""
+
+        from pytest_bdd import scenarios
+
+        scenarios('features')
+    """))
+    result = testdir.runpytest()
+    result.stdout.fnmatch_lines(
+        [
+            '*FeatureError: Step definition outside of a Scenario or a Background.*',
+        ],
+    )


### PR DESCRIPTION
Fixes #156 
Actually the current error is correct, only the message is ambiguous.
It should be a FeatureError to communicate the line where it breaks and it should mention that the step is defined outside of a scenario or a background.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pytest-dev/pytest-bdd/185)
<!-- Reviewable:end -->
