### PR TITLE
Allow spaces in tags

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-2.16.2
+2.17.0
 ------
 
 - Fix FixtureDef signature for newer pytest versions (The-Compiler)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@ Changelog
 - Fix FixtureDef signature for newer pytest versions (The-Compiler)
 - Better error explanation for the steps defined outside of scenarios (olegpidsadnyi)
 - Add a ``pytest_bdd_apply_tag`` hook to customize handling of tags (The-Compiler)
+- Allow spaces in tag names. This can be useful when using the
+  ``pytest_bdd_apply_tag`` hook with tags like ``@xfail: Some reason``.
 
 
 2.16.1

--- a/pytest_bdd/__init__.py
+++ b/pytest_bdd/__init__.py
@@ -3,6 +3,6 @@
 from pytest_bdd.steps import given, when, then
 from pytest_bdd.scenario import scenario, scenarios
 
-__version__ = '2.16.2'
+__version__ = '2.17.0'
 
 __all__ = [given.__name__, when.__name__, then.__name__, scenario.__name__, scenarios.__name__]

--- a/pytest_bdd/feature.py
+++ b/pytest_bdd/feature.py
@@ -134,9 +134,10 @@ def get_tags(line):
 
     :return: List of tags.
     """
+    if not line or '@' not in line.strip():
+        return set()
     return (
-        set((tag[1:] for tag in line.split() if tag.startswith("@") and len(tag) > 1))
-        if line else set()
+        set((tag.lstrip('@') for tag in line.strip().split(' @') if len(tag) > 1))
     )
 
 


### PR DESCRIPTION
Even if I originally told @olegpidsadnyi I'd drop this, here I am :laughing: 

It'd be nice for things like `@xfail: Issue #123` and it also makes the code in `get_tags` a bit simpler IMHO.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pytest-dev/pytest-bdd/188)
<!-- Reviewable:end -->
