### PR TITLE
Don't use skip-mark in test_apply_tag_hook

### DIFF
--- a/tests/feature/test_tags.py
+++ b/tests/feature/test_tags.py
@@ -120,7 +120,7 @@ def test_apply_tag_hook(testdir):
         Scenario: Tags
             Given I have a bar
 
-        @skip
+        @xfail
         Scenario: Tags 2
             Given I have a bar
     """)
@@ -133,14 +133,9 @@ def test_apply_tag_hook(testdir):
 
         scenarios('test.feature')
     """)
-    result = testdir.runpytest('-rs')
+    result = testdir.runpytest('-rsx')
     result.stdout.fnmatch_lines(["SKIP *: Not implemented yet"])
-    result.stdout.fnmatch_lines(
-        [
-            "SKIP *: unconditional skip",
-            "*= 2 skipped * =*",
-        ],
-    )
+    result.stdout.fnmatch_lines(["*= 1 skipped, 1 xpassed * =*"])
 
 
 def test_tag_with_spaces(testdir):


### PR DESCRIPTION
`@pytest.mark.skip` was only introduced in pytest 2.9. Use `xfail` for
testing instead which will work with older pytest versions as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pytest-dev/pytest-bdd/189)
<!-- Reviewable:end -->
