### PR TITLE
Don't run tests in linters tox env

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ deps = -r{toxinidir}/requirements-testing.txt
 
 [testenv:linters]
 interpreter=python2.7
-commands={[testenv]commands} pytest_bdd --pep8
+commands={[testenv]commands} pytest_bdd --pep8 -m pep8
 
 [testenv:py27-xdist]
 basepython=python2.7


### PR DESCRIPTION
pytest-pep8 adds some new tests, but without selecting only them (via -m
pep8), the tests would run in the linters env as well.