### PR TITLE
[WIP] Initial attempt at pytest 3.0 compatibility

### DIFF
--- a/pytest_bdd/scenario.py
+++ b/pytest_bdd/scenario.py
@@ -39,7 +39,7 @@ from .steps import (
     recreate_function,
 )
 from .types import GIVEN
-from .utils import get_args
+from .utils import get_args, get_fixture_value
 
 if six.PY3:  # pragma: no cover
     import runpy
@@ -71,7 +71,7 @@ def find_argumented_step_fixture_name(name, type_, fixturemanager, request=None)
                 parser_name = get_step_fixture_name(parser.name, type_)
                 if request:
                     try:
-                        request.getfuncargvalue(parser_name)
+                        get_fixture_value(request, parser_name)
                     except pytest_fixtures.FixtureLookupError:
                         continue
                 return parser_name
@@ -89,12 +89,12 @@ def _find_step_function(request, step, scenario, encoding):
     """
     name = step.name
     try:
-        return request.getfuncargvalue(get_step_fixture_name(name, step.type, encoding))
+        return get_fixture_value(request, get_step_fixture_name(name, step.type, encoding))
     except pytest_fixtures.FixtureLookupError:
         try:
             name = find_argumented_step_fixture_name(name, step.type, request._fixturemanager, request)
             if name:
-                return request.getfuncargvalue(name)
+                return get_fixture_value(request, name)
             raise
         except pytest_fixtures.FixtureLookupError:
             raise exceptions.StepDefinitionNotFoundError(
@@ -129,7 +129,7 @@ def _execute_step_function(request, scenario, step, step_func):
     kw["step_func_args"] = {}
     try:
         # Get the step argument values.
-        kwargs = dict((arg, request.getfuncargvalue(arg)) for arg in get_args(step_func))
+        kwargs = dict((arg, get_fixture_value(request, arg)) for arg in get_args(step_func))
         kw["step_func_args"] = kwargs
 
         request.config.hook.pytest_bdd_before_step_call(**kw)

--- a/pytest_bdd/utils.py
+++ b/pytest_bdd/utils.py
@@ -39,7 +39,7 @@ def get_fixture_value(request, name):
 def get_fixture_value_raw(request, name):
     """Set the given raw fixture value from the pytest request object."""
     try:
-        return request._fixture_values.get((name, request.scope))
+        return request._fixture_values.get(name)
     except AttributeError:
         return request._funcargs.get(name)
 
@@ -47,6 +47,28 @@ def get_fixture_value_raw(request, name):
 def set_fixture_value(request, name, value):
     """Set the given fixture value on the pytest request object."""
     try:
-        request._fixture_values[(name, request.scope)] = value
+        request._fixture_values[name] = value
     except AttributeError:
         request._funcargs[name] = value
+
+
+def get_request_fixture_defs(request):
+    """Get the internal list of FixtureDefs cached into the given request object.
+
+    Compatibility with pytest 3.0.
+    """
+    try:
+        return request._fixture_defs
+    except AttributeError:
+        return getattr(request, "_fixturedefs", {})
+
+
+def get_request_fixture_names(request):
+    """Get list of fixture names for the given FixtureRequest.
+
+    Get the internal and mutable list of fixture names in the enclosing scope of
+    the given request object.
+
+    Compatibility with pytest 3.0.
+    """
+    return request._pyfuncitem._fixtureinfo.names_closure

--- a/pytest_bdd/utils.py
+++ b/pytest_bdd/utils.py
@@ -21,3 +21,32 @@ def get_args(func):
                 if param.kind == param.POSITIONAL_OR_KEYWORD]
     else:
         return inspect.getargspec(func).args
+
+
+def get_fixture_value(request, name):
+    """Get the given fixture from the pytest request object.
+
+    getfuncargvalue() is deprecated in pytest 3.0, so we need to use
+    getfixturevalue() there.
+    """
+    try:
+        getfixturevalue = request.getfixturevalue
+    except AttributeError:
+        getfixturevalue = request.getfuncargvalue
+    return getfixturevalue(name)
+
+
+def get_fixture_value_raw(request, name):
+    """Set the given raw fixture value from the pytest request object."""
+    try:
+        return request._fixture_values.get((name, request.scope))
+    except AttributeError:
+        return request._funcargs.get(name)
+
+
+def set_fixture_value(request, name, value):
+    """Set the given fixture value on the pytest request object."""
+    try:
+        request._fixture_values[(name, request.scope)] = value
+    except AttributeError:
+        request._funcargs[name] = value

--- a/tests/feature/test_cucumber_json.py
+++ b/tests/feature/test_cucumber_json.py
@@ -158,7 +158,7 @@ def test_step_trace(testdir):
                     "type": "scenario"
                 }
             ],
-            "id": "test_step_trace0/test.feature",
+            "id": os.path.join("test_step_trace0", "test.feature"),
             "keyword": "Feature",
             "line": 2,
             "name": "One passing scenario, one failing scenario",

--- a/tests/feature/test_multiline.py
+++ b/tests/feature/test_multiline.py
@@ -10,6 +10,7 @@ from pytest_bdd import (
     scenario,
     then,
 )
+from pytest_bdd.utils import get_fixture_value
 
 
 @pytest.mark.parametrize(["feature_text", "expected_text"], [
@@ -72,7 +73,7 @@ def test_multiline(request, tmpdir, feature_text, expected_text):
 
     @scenario(file_name.strpath, 'Multiline step using sub indentation')
     def test_multiline(request):
-        assert request.getfuncargvalue('i_have_text') == expected_text
+        assert get_fixture_value(request, 'i_have_text') == expected_text
     test_multiline(request)
 
 

--- a/tests/library/child/test_local_override.py
+++ b/tests/library/child/test_local_override.py
@@ -5,6 +5,7 @@ Check the parent given steps are collected, override them locally.
 
 from pytest_bdd import given
 from pytest_bdd.steps import get_step_fixture_name, GIVEN
+from pytest_bdd.utils import get_fixture_value
 
 
 @given('I have locally overriden fixture')
@@ -21,10 +22,12 @@ def test_override(request, overridable):
     """Test locally overriden fixture."""
 
     # Test the fixture is also collected by the text name
-    assert request.getfuncargvalue(get_step_fixture_name('I have locally overriden fixture', GIVEN))(request) == 'local'
+    fixture = get_fixture_value(request, get_step_fixture_name('I have locally overriden fixture', GIVEN))
+    assert fixture(request) == 'local'
 
     # 'I have the overriden fixture' stands for overridable and is overriden locally
-    assert request.getfuncargvalue(get_step_fixture_name('I have the overriden fixture', GIVEN))(request) == 'local'
+    fixture = get_fixture_value(request, get_step_fixture_name('I have the overriden fixture', GIVEN))
+    assert fixture(request) == 'local'
 
     assert overridable == 'local'
 

--- a/tests/library/test_parent.py
+++ b/tests/library/test_parent.py
@@ -3,6 +3,7 @@
 Check the parent givens are collected and overriden in the local conftest.
 """
 from pytest_bdd.steps import get_step_fixture_name, WHEN
+from pytest_bdd.utils import get_fixture_value
 
 
 def test_parent(parent, overridable):
@@ -16,4 +17,4 @@ def test_parent(parent, overridable):
 
 def test_global_when_step(request):
     """Test when step defined in the parent conftest."""
-    request.getfuncargvalue(get_step_fixture_name('I use a when step from the parent conftest', WHEN))
+    get_fixture_value(request, get_step_fixture_name('I use a when step from the parent conftest', WHEN))

--- a/tests/steps/test_steps.py
+++ b/tests/steps/test_steps.py
@@ -3,6 +3,7 @@
 import pytest
 from pytest_bdd import given, when, then
 from pytest_bdd.steps import get_step_fixture_name, WHEN, THEN
+from pytest_bdd.utils import get_fixture_value
 
 
 @when('I do stuff')
@@ -21,10 +22,10 @@ def test_when_then(request):
     This test checks that when and then are not evaluated
     during fixture collection that might break the scenario.
     """
-    do_stuff_ = request.getfuncargvalue(get_step_fixture_name('I do stuff', WHEN))
+    do_stuff_ = get_fixture_value(request, get_step_fixture_name('I do stuff', WHEN))
     assert callable(do_stuff_)
 
-    check_stuff_ = request.getfuncargvalue(get_step_fixture_name('I check stuff', THEN))
+    check_stuff_ = get_fixture_value(request, get_step_fixture_name('I check stuff', THEN))
     assert callable(check_stuff_)
 
 


### PR DESCRIPTION
This fixes the obvious issues I saw, though I'm not sure if the `_funcargs` compatibility code actually does the right thing with pytest 3.0... Maybe @nicoddemus can chime in?

FWIW I still get a lot of errors, most of them due to a failing `list.remove`:

```
=============================================== ERRORS ===============================================
__________________________________ ERROR at teardown of test_steps ___________________________________

    def fin():
        request._fixturemanager._arg2fixturedefs[arg].remove(fd)
        getattr(request, "_fixturedefs", {})[arg] = old_fd
        set_fixture_value(request, arg, old_value)
        if add_fixturename:
>           request.fixturenames.remove(arg)
E           ValueError: list.remove(x): x not in list

add_fixturename = True
arg        = 'euro'
fd         = <FixtureDef name='euro' scope='function' baseid='' >
old_fd     = None
old_value  = 2
request    = <FixtureRequest for <Function 'test_steps'>>

.tox/py34/lib/python3.4/site-packages/pytest_bdd/steps.py:314: ValueError
_________________________ ERROR at teardown of test_argument_in_when_step_1 __________________________

    def fin():
        request._fixturemanager._arg2fixturedefs[arg].remove(fd)
        getattr(request, "_fixturedefs", {})[arg] = old_fd
        set_fixture_value(request, arg, old_value)
        if add_fixturename:
>           request.fixturenames.remove(arg)
E           ValueError: list.remove(x): x not in list

add_fixturename = True
arg        = 'arg'
fd         = <FixtureDef name='arg' scope='function' baseid='' >
old_fd     = None
old_value  = '5'
request    = <FixtureRequest for <Function 'test_argument_in_when_step_1'>>

.tox/py34/lib/python3.4/site-packages/pytest_bdd/steps.py:314: ValueError
_________________________ ERROR at teardown of test_argument_in_when_step_2 __________________________

    def fin():
        request._fixturemanager._arg2fixturedefs[arg].remove(fd)
        getattr(request, "_fixturedefs", {})[arg] = old_fd
        set_fixture_value(request, arg, old_value)
        if add_fixturename:
>           request.fixturenames.remove(arg)
E           ValueError: list.remove(x): x not in list

add_fixturename = True
arg        = 'arg'
fd         = <FixtureDef name='arg' scope='function' baseid='' >
old_fd     = None
old_value  = '10'
request    = <FixtureRequest for <Function 'test_argument_in_when_step_2'>>

.tox/py34/lib/python3.4/site-packages/pytest_bdd/steps.py:314: ValueError
______________________________ ERROR at teardown of test_multiple_given ______________________________

    def fin():
        request._fixturemanager._arg2fixturedefs[arg].remove(fd)
        getattr(request, "_fixturedefs", {})[arg] = old_fd
        set_fixture_value(request, arg, old_value)
        if add_fixturename:
>           request.fixturenames.remove(arg)
E           ValueError: list.remove(x): x not in list

add_fixturename = True
arg        = 'euro'
fd         = <FixtureDef name='euro' scope='function' baseid='' >
old_fd     = None
old_value  = 1
request    = <FixtureRequest for <Function 'test_multiple_given'>>

.tox/py34/lib/python3.4/site-packages/pytest_bdd/steps.py:314: ValueError
__________________________________ ERROR at teardown of test_steps ___________________________________

    def fin():
        request._fixturemanager._arg2fixturedefs[arg].remove(fd)
        getattr(request, "_fixturedefs", {})[arg] = old_fd
        set_fixture_value(request, arg, old_value)
        if add_fixturename:
>           request.fixturenames.remove(arg)
E           ValueError: list.remove(x): x not in list

add_fixturename = True
arg        = 'euro'
fd         = <FixtureDef name='euro' scope='function' baseid='' >
old_fd     = None
old_value  = 2
request    = <FixtureRequest for <Function 'test_steps'>>

.tox/py34/lib/python3.4/site-packages/pytest_bdd/steps.py:314: ValueError
_________________________ ERROR at teardown of test_argument_in_when_step_1 __________________________

    def fin():
        request._fixturemanager._arg2fixturedefs[arg].remove(fd)
        getattr(request, "_fixturedefs", {})[arg] = old_fd
        set_fixture_value(request, arg, old_value)
        if add_fixturename:
>           request.fixturenames.remove(arg)
E           ValueError: list.remove(x): x not in list

add_fixturename = True
arg        = 'arg'
fd         = <FixtureDef name='arg' scope='function' baseid='' >
old_fd     = None
old_value  = '5'
request    = <FixtureRequest for <Function 'test_argument_in_when_step_1'>>

.tox/py34/lib/python3.4/site-packages/pytest_bdd/steps.py:314: ValueError
_________________________ ERROR at teardown of test_argument_in_when_step_2 __________________________

    def fin():
        request._fixturemanager._arg2fixturedefs[arg].remove(fd)
        getattr(request, "_fixturedefs", {})[arg] = old_fd
        set_fixture_value(request, arg, old_value)
        if add_fixturename:
>           request.fixturenames.remove(arg)
E           ValueError: list.remove(x): x not in list

add_fixturename = True
arg        = 'arg'
fd         = <FixtureDef name='arg' scope='function' baseid='' >
old_fd     = None
old_value  = '10'
request    = <FixtureRequest for <Function 'test_argument_in_when_step_2'>>

.tox/py34/lib/python3.4/site-packages/pytest_bdd/steps.py:314: ValueError
______________________________ ERROR at teardown of test_multiple_given ______________________________

    def fin():
        request._fixturemanager._arg2fixturedefs[arg].remove(fd)
        getattr(request, "_fixturedefs", {})[arg] = old_fd
        set_fixture_value(request, arg, old_value)
        if add_fixturename:
>           request.fixturenames.remove(arg)
E           ValueError: list.remove(x): x not in list

add_fixturename = True
arg        = 'euro'
fd         = <FixtureDef name='euro' scope='function' baseid='' >
old_fd     = None
old_value  = 1
request    = <FixtureRequest for <Function 'test_multiple_given'>>

.tox/py34/lib/python3.4/site-packages/pytest_bdd/steps.py:314: ValueError
__________________________________ ERROR at teardown of test_steps ___________________________________

    def fin():
        request._fixturemanager._arg2fixturedefs[arg].remove(fd)
        getattr(request, "_fixturedefs", {})[arg] = old_fd
        set_fixture_value(request, arg, old_value)
        if add_fixturename:
>           request.fixturenames.remove(arg)
E           ValueError: list.remove(x): x not in list

add_fixturename = True
arg        = 'euro'
fd         = <FixtureDef name='euro' scope='function' baseid='' >
old_fd     = None
old_value  = 1
request    = <FixtureRequest for <Function 'test_steps'>>

.tox/py34/lib/python3.4/site-packages/pytest_bdd/steps.py:314: ValueError
_________________________ ERROR at teardown of test_argument_in_when_step_1 __________________________

    def fin():
        request._fixturemanager._arg2fixturedefs[arg].remove(fd)
        getattr(request, "_fixturedefs", {})[arg] = old_fd
        set_fixture_value(request, arg, old_value)
        if add_fixturename:
>           request.fixturenames.remove(arg)
E           ValueError: list.remove(x): x not in list

add_fixturename = True
arg        = 'arg'
fd         = <FixtureDef name='arg' scope='function' baseid='' >
old_fd     = None
old_value  = '5'
request    = <FixtureRequest for <Function 'test_argument_in_when_step_1'>>

.tox/py34/lib/python3.4/site-packages/pytest_bdd/steps.py:314: ValueError
_________________________ ERROR at teardown of test_argument_in_when_step_2 __________________________

    def fin():
        request._fixturemanager._arg2fixturedefs[arg].remove(fd)
        getattr(request, "_fixturedefs", {})[arg] = old_fd
        set_fixture_value(request, arg, old_value)
        if add_fixturename:
>           request.fixturenames.remove(arg)
E           ValueError: list.remove(x): x not in list

add_fixturename = True
arg        = 'arg'
fd         = <FixtureDef name='arg' scope='function' baseid='' >
old_fd     = None
old_value  = '10'
request    = <FixtureRequest for <Function 'test_argument_in_when_step_2'>>

.tox/py34/lib/python3.4/site-packages/pytest_bdd/steps.py:314: ValueError
______________________________ ERROR at teardown of test_multiple_given ______________________________

    def fin():
        request._fixturemanager._arg2fixturedefs[arg].remove(fd)
        getattr(request, "_fixturedefs", {})[arg] = old_fd
        set_fixture_value(request, arg, old_value)
        if add_fixturename:
>           request.fixturenames.remove(arg)
E           ValueError: list.remove(x): x not in list

add_fixturename = True
arg        = 'euro'
fd         = <FixtureDef name='euro' scope='function' baseid='' >
old_fd     = None
old_value  = 2
request    = <FixtureRequest for <Function 'test_multiple_given'>>

.tox/py34/lib/python3.4/site-packages/pytest_bdd/steps.py:314: ValueError
__________________________________ ERROR at teardown of test_steps ___________________________________

    def fin():
        request._fixturemanager._arg2fixturedefs[arg].remove(fd)
        getattr(request, "_fixturedefs", {})[arg] = old_fd
        set_fixture_value(request, arg, old_value)
        if add_fixturename:
>           request.fixturenames.remove(arg)
E           ValueError: list.remove(x): x not in list

add_fixturename = True
arg        = 'n'
fd         = <FixtureDef name='n' scope='function' baseid='' >
old_fd     = None
old_value  = 2
request    = <FixtureRequest for <Function 'test_steps'>>

.tox/py34/lib/python3.4/site-packages/pytest_bdd/steps.py:314: ValueError
_____________________________ ERROR at teardown of test_background_basic _____________________________

    def fin():
        request._fixturemanager._arg2fixturedefs[arg].remove(fd)
        getattr(request, "_fixturedefs", {})[arg] = old_fd
        set_fixture_value(request, arg, old_value)
        if add_fixturename:
>           request.fixturenames.remove(arg)
E           ValueError: list.remove(x): x not in list

add_fixturename = True
arg        = 'data'
fd         = <FixtureDef name='data' scope='function' baseid='' >
old_fd     = None
old_value  = None
request    = <FixtureRequest for <Function 'test_background_basic'>>

.tox/py34/lib/python3.4/site-packages/pytest_bdd/steps.py:314: ValueError
__________________________ ERROR at teardown of test_background_check_order __________________________

    def fin():
        request._fixturemanager._arg2fixturedefs[arg].remove(fd)
        getattr(request, "_fixturedefs", {})[arg] = old_fd
        set_fixture_value(request, arg, old_value)
        if add_fixturename:
>           request.fixturenames.remove(arg)
E           ValueError: list.remove(x): x not in list

add_fixturename = True
arg        = 'data'
fd         = <FixtureDef name='data' scope='function' baseid='' >
old_fd     = None
old_value  = None
request    = <FixtureRequest for <Function 'test_background_check_order'>>

.tox/py34/lib/python3.4/site-packages/pytest_bdd/steps.py:314: ValueError
 ERROR at teardown of test_multiline[\nScenario: Multiline step using sub indentation\n    Given I have a step with:\n        Some\n\n        Extra\n        Lines\n    Then the text should be parsed with correct indentation\n-Some\n\nExtra\nLines] 

    def fin():
        request._fixturemanager._arg2fixturedefs[arg].remove(fd)
        getattr(request, "_fixturedefs", {})[arg] = old_fd
        set_fixture_value(request, arg, old_value)
        if add_fixturename:
>           request.fixturenames.remove(arg)
E           ValueError: list.remove(x): x not in list

add_fixturename = True
arg        = 'text'
fd         = <FixtureDef name='text' scope='function' baseid='' >
old_fd     = None
old_value  = None
request    = <FixtureRequest for <Function 'test_multiline[\\nScenario: Multiline step using sub indentation\\n    Given I have a s...     Extra\\n        Lines\\n    Then the text should be parsed with correct indentation\\n-Some\\n\\nExtra\\nLines]'>>

.tox/py34/lib/python3.4/site-packages/pytest_bdd/steps.py:314: ValueError
 ERROR at teardown of test_multiline[\nScenario: Multiline step using sub indentation\n    Given I have a step with:\n        Some\n\n      Extra\n     Lines\n\n    Then the text should be parsed with correct indentation\n-   Some\n\n Extra\nLines] 

    def fin():
        request._fixturemanager._arg2fixturedefs[arg].remove(fd)
        getattr(request, "_fixturedefs", {})[arg] = old_fd
        set_fixture_value(request, arg, old_value)
        if add_fixturename:
>           request.fixturenames.remove(arg)
E           ValueError: list.remove(x): x not in list

add_fixturename = True
arg        = 'text'
fd         = <FixtureDef name='text' scope='function' baseid='' >
old_fd     = None
old_value  = None
request    = <FixtureRequest for <Function 'test_multiline[\\nScenario: Multiline step using sub indentation\\n    Given I have a s... Extra\\n     Lines\\n\\n    Then the text should be parsed with correct indentation\\n-   Some\\n\\n Extra\\nLines]'>>

.tox/py34/lib/python3.4/site-packages/pytest_bdd/steps.py:314: ValueError
 ERROR at teardown of test_multiline[\nFeature:\nScenario: Multiline step using sub indentation\n    Given I have a step with:\n        Some\n        Extra\n        Lines\n\n-Some\nExtra\nLines] 

    def fin():
        request._fixturemanager._arg2fixturedefs[arg].remove(fd)
        getattr(request, "_fixturedefs", {})[arg] = old_fd
        set_fixture_value(request, arg, old_value)
        if add_fixturename:
>           request.fixturenames.remove(arg)
E           ValueError: list.remove(x): x not in list

add_fixturename = True
arg        = 'text'
fd         = <FixtureDef name='text' scope='function' baseid='' >
old_fd     = None
old_value  = None
request    = <FixtureRequest for <Function 'test_multiline[\\nFeature:\\nScenario: Multiline step using sub indentation\\n    Given I have a step with:\\n        Some\\n        Extra\\n        Lines\\n\\n-Some\\nExtra\\nLines]'>>

.tox/py34/lib/python3.4/site-packages/pytest_bdd/steps.py:314: ValueError
__________________________ ERROR at teardown of test_multiline_wrong_indent __________________________

    def fin():
        request._fixturemanager._arg2fixturedefs[arg].remove(fd)
        getattr(request, "_fixturedefs", {})[arg] = old_fd
        set_fixture_value(request, arg, old_value)
        if add_fixturename:
>           request.fixturenames.remove(arg)
E           ValueError: list.remove(x): x not in list

add_fixturename = True
arg        = 'text'
fd         = <FixtureDef name='text' scope='function' baseid='' >
old_fd     = None
old_value  = None
request    = <FixtureRequest for <Function 'test_multiline_wrong_indent'>>

.tox/py34/lib/python3.4/site-packages/pytest_bdd/steps.py:314: ValueError
____________________________ ERROR at teardown of test_scenario_comments _____________________________

    def fin():
        request._fixturemanager._arg2fixturedefs[arg].remove(fd)
        getattr(request, "_fixturedefs", {})[arg] = old_fd
        set_fixture_value(request, arg, old_value)
        if add_fixturename:
>           request.fixturenames.remove(arg)
E           ValueError: list.remove(x): x not in list

add_fixturename = True
arg        = 'acomment'
fd         = <FixtureDef name='acomment' scope='function' baseid='' >
old_fd     = None
old_value  = 'a#comment'
request    = <FixtureRequest for <Function 'test_scenario_comments'>>

.tox/py34/lib/python3.4/site-packages/pytest_bdd/steps.py:314: ValueError
_____________________________ ERROR at teardown of test_given_injection ______________________________

    def fin():
        request._fixturemanager._arg2fixturedefs[arg].remove(fd)
        getattr(request, "_fixturedefs", {})[arg] = old_fd
        set_fixture_value(request, arg, old_value)
        if add_fixturename:
>           request.fixturenames.remove(arg)
E           ValueError: list.remove(x): x not in list

add_fixturename = True
arg        = 'foo'
fd         = <FixtureDef name='foo' scope='function' baseid='' >
old_fd     = None
old_value  = None
request    = <FixtureRequest for <Function 'test_given_injection'>>

.tox/py34/lib/python3.4/site-packages/pytest_bdd/steps.py:314: ValueError
____________________ ERROR at teardown of test_steps_in_feature_file_have_unicode ____________________

    def fin():
        request._fixturemanager._arg2fixturedefs[arg].remove(fd)
        getattr(request, "_fixturedefs", {})[arg] = old_fd
        set_fixture_value(request, arg, old_value)
        if add_fixturename:
>           request.fixturenames.remove(arg)
E           ValueError: list.remove(x): x not in list

add_fixturename = True
arg        = 'content'
fd         = <FixtureDef name='content' scope='function' baseid='' >
old_fd     = None
old_value  = 'якийсь контент'
request    = <FixtureRequest for <Function 'test_steps_in_feature_file_have_unicode'>>

.tox/py34/lib/python3.4/site-packages/pytest_bdd/steps.py:314: ValueError
```

And various others:

```
============================================== FAILURES ==============================================
________________________________________ test_arg_fixture_mix ________________________________________

testdir = <Testdir local('/tmp/pytest-of-florian/pytest-66/testdir/test_arg_fixture_mix0')>

    def test_arg_fixture_mix(testdir):
    
        subdir = testdir.mkpydir("arg_fixture_mix")
        subdir.join("test_a.py").write(py.code.Source("""
            import re
            import pytest
            from pytest_bdd import scenario, given, then, parsers
    
    
            @pytest.fixture
            def foo():
                return "fine"
    
            @scenario(
                'arg_and_fixture_mix.feature',
                'Use the step argument with the same name as fixture of another test',
            )
            def test_args():
                pass
    
            @given(parsers.parse('foo is "{foo}"'))
            def foo1(foo):
                pass
    
    
            @then(parsers.parse('foo should be "{foo_value}"'))
            def foo_should_be(foo, foo_value):
                assert foo == foo_value
    
            @scenario(
                'arg_and_fixture_mix.feature',
                'Everything is fine',
            )
            def test_bar():
                pass
    
            @given('it is all fine')
            def fine():
                return "fine"
    
    
            @then('foo should be fine')
            def foo_should_be_fine(foo):
                assert foo == "fine"
        """))
    
        subdir.join("test_b.py").write(py.code.Source("""
            import re
            import pytest
            from pytest_bdd import scenario, given, then
    
            @scenario(
                'arg_and_fixture_mix.feature',
                'Everything is fine',
            )
            def test_args():
                pass
    
            @pytest.fixture
            def foo():
                return "fine"
    
    
            @given('it is all fine')
            def fine():
                return "fine"
    
    
            @then('foo should be fine')
            def foo_should_be(foo):
                assert foo == "fine"
    
    
            def test_bar(foo):
                assert foo == 'fine'
        """))
    
        subdir.join("arg_and_fixture_mix.feature").write("""
            Scenario: Use the step argument with the same name as fixture of another test
            Given foo is "Hello"
            Then foo should be "Hello"
    
    
            Scenario: Everything is fine
                Given it is all fine
                Then foo should be fine
        """)
    
        result = testdir.runpytest("-k arg_fixture_mix")
>       assert result.ret == 0
E       assert 1 == 0
E        +  where 1 = <_pytest.pytester.RunResult object at 0x7f69813b9cf8>.ret

result     = <_pytest.pytester.RunResult object at 0x7f69813b9cf8>
subdir     = local('/tmp/pytest-of-florian/pytest-66/testdir/test_arg_fixture_mix0/arg_fixture_mix')
testdir    = <Testdir local('/tmp/pytest-of-florian/pytest-66/testdir/test_arg_fixture_mix0')>

/home/florian/proj/pytest-bdd/tests/args/test_arg_fixture_mix.py:93: AssertionError
---------------------------------------- Captured stdout call ----------------------------------------
============================= test session starts ==============================
platform linux -- Python 3.4.5, pytest-3.0.0.dev1, py-1.4.31, pluggy-0.3.1
rootdir: /tmp/pytest-of-florian/pytest-66/testdir/test_arg_fixture_mix0, inifile: 
plugins: xdist-1.13.1, pep8-1.0.6, bdd-2.17.0
collected 4 items

arg_fixture_mix/test_a.py FE.
arg_fixture_mix/test_b.py ..

==================================== ERRORS ====================================
________________________ ERROR at teardown of test_args ________________________

    def fin():
        request._fixturemanager._arg2fixturedefs[arg].remove(fd)
        getattr(request, "_fixturedefs", {})[arg] = old_fd
        set_fixture_value(request, arg, old_value)
        if add_fixturename:
>           request.fixturenames.remove(arg)
E           ValueError: list.remove(x): x not in list

/home/florian/proj/pytest-bdd/.tox/py34/lib/python3.4/site-packages/pytest_bdd/steps.py:314: ValueError
=================================== FAILURES ===================================
__________________________________ test_args ___________________________________

request = <FixtureRequest for <Function 'test_args'>>

    'Use the step argument with the same name as fixture of another test',
>   )
    def test_args():

arg_fixture_mix/test_a.py:14: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/home/florian/proj/pytest-bdd/.tox/py34/lib/python3.4/site-packages/pytest_bdd/scenario.py:195: in _execute_scenario
    _execute_step_function(request, scenario, step, step_func)
/home/florian/proj/pytest-bdd/.tox/py34/lib/python3.4/site-packages/pytest_bdd/scenario.py:137: in _execute_step_function
    step_func(**kwargs)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

foo = 'fine', foo_value = 'Hello'

    @then(parsers.parse('foo should be "{foo_value}"'))
    def foo_should_be(foo, foo_value):
>       assert foo == foo_value
E       assert 'fine' == 'Hello'
E         - fine
E         + Hello

arg_fixture_mix/test_a.py:25: AssertionError
================= 1 failed, 3 passed, 1 error in 0.06 seconds ==================
_____________________________________________ test_steps _____________________________________________

request = <FixtureRequest for <Function 'test_steps'>>

    @scenario_args('Every step takes a parameter with the same name')
>   def test_steps():

request    = <FixtureRequest for <Function 'test_steps'>>

tests/args/cfparse/test_args.py:22: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
.tox/py34/lib/python3.4/site-packages/pytest_bdd/scenario.py:195: in _execute_scenario
    _execute_step_function(request, scenario, step, step_func)
.tox/py34/lib/python3.4/site-packages/pytest_bdd/scenario.py:137: in _execute_step_function
    step_func(**kwargs)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

euro = 1, values = [1, 0, 999999], request = <FixtureRequest for <Function 'test_steps'>>

    @when(parsers.cfparse('I pay {euro:d} Euro'))
    def i_pay(euro, values, request):
>       assert euro == values.pop(0)
E       assert 1 == 2
E        +  where 2 = <built-in method pop of list object at 0x7f69812ada08>(0)
E        +    where <built-in method pop of list object at 0x7f69812ada08> = [1, 0, 999999].pop

euro       = 1
request    = <FixtureRequest for <Function 'test_steps'>>
values     = [1, 0, 999999]

tests/args/cfparse/test_args.py:52: AssertionError
_____________________________________________ test_steps _____________________________________________

request = <FixtureRequest for <Function 'test_steps'>>

    @scenario_args('Every step takes a parameter with the same name')
>   def test_steps():

request    = <FixtureRequest for <Function 'test_steps'>>

tests/args/parse/test_args.py:22: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
.tox/py34/lib/python3.4/site-packages/pytest_bdd/scenario.py:195: in _execute_scenario
    _execute_step_function(request, scenario, step, step_func)
.tox/py34/lib/python3.4/site-packages/pytest_bdd/scenario.py:137: in _execute_step_function
    step_func(**kwargs)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

euro = 1, values = [1, 0, 999999], request = <FixtureRequest for <Function 'test_steps'>>

    @when(parsers.parse('I pay {euro:d} Euro'))
    def i_pay(euro, values, request):
>       assert euro == values.pop(0)
E       assert 1 == 2
E        +  where 2 = <built-in method pop of list object at 0x7f69812b56c8>(0)
E        +    where <built-in method pop of list object at 0x7f69812b56c8> = [1, 0, 999999].pop

euro       = 1
request    = <FixtureRequest for <Function 'test_steps'>>
values     = [1, 0, 999999]

tests/args/parse/test_args.py:52: AssertionError
_____________________________________________ test_steps _____________________________________________

request = <FixtureRequest for <Function 'test_steps'>>

    @scenario_args('Every step takes a parameter with the same name')
>   def test_steps():

request    = <FixtureRequest for <Function 'test_steps'>>

tests/args/regex/test_args.py:23: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
.tox/py34/lib/python3.4/site-packages/pytest_bdd/scenario.py:195: in _execute_scenario
    _execute_step_function(request, scenario, step, step_func)
.tox/py34/lib/python3.4/site-packages/pytest_bdd/scenario.py:137: in _execute_step_function
    step_func(**kwargs)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

euro = 1, values = [1, 0, 999999], request = <FixtureRequest for <Function 'test_steps'>>

    @when(parsers.re(r'I pay (?P<euro>\d+) Euro'), converters=dict(euro=int))
    def i_pay(euro, values, request):
>       assert euro == values.pop(0)
E       assert 1 == 2
E        +  where 2 = <built-in method pop of list object at 0x7f69812d6808>(0)
E        +    where <built-in method pop of list object at 0x7f69812d6808> = [1, 0, 999999].pop

euro       = 1
request    = <FixtureRequest for <Function 'test_steps'>>
values     = [1, 0, 999999]

tests/args/regex/test_args.py:53: AssertionError
_____________________________________________ test_steps _____________________________________________

request = <FixtureRequest for <Function 'test_steps'>>

    'Executed with steps matching step definitons with arguments',
>   )
    def test_steps():

request    = <FixtureRequest for <Function 'test_steps'>>

tests/args/subfolder/test_args.py:15: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
.tox/py34/lib/python3.4/site-packages/pytest_bdd/scenario.py:195: in _execute_scenario
    _execute_step_function(request, scenario, step, step_func)
.tox/py34/lib/python3.4/site-packages/pytest_bdd/scenario.py:137: in _execute_step_function
    step_func(**kwargs)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

results = [1, 1, 1]

    @then('the list should be [1, 2, 3]')
    def check_results(results):
>       assert results == [1, 2, 3]
E       assert [1, 1, 1] == [1, 2, 3]
E         At index 1 diff: 1 != 2
E         Full diff:
E         - [1, 1, 1]
E         ?     ^  ^
E         + [1, 2, 3]
E         ?     ^  ^

results    = [1, 1, 1]

tests/args/subfolder/test_args.py:42: AssertionError
________________________________________ test_given_injection ________________________________________

request = <FixtureRequest for <Function 'test_given_injection'>>

    @scenario('given.feature', 'Test given fixture injection')
>   def test_given_injection():

request    = <FixtureRequest for <Function 'test_given_injection'>>

tests/steps/test_given.py:37: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
.tox/py34/lib/python3.4/site-packages/pytest_bdd/scenario.py:195: in _execute_scenario
    _execute_step_function(request, scenario, step, step_func)
.tox/py34/lib/python3.4/site-packages/pytest_bdd/scenario.py:137: in _execute_step_function
    step_func(**kwargs)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

foo = 'foo'

    @then('foo should be "injected foo"')
    def foo_is_foo(foo):
>       assert foo == 'injected foo'
E       assert 'foo' == 'injected foo'
E         - foo
E         + injected foo

foo        = 'foo'

tests/steps/test_given.py:48: AssertionError
=========================== 6 failed, 119 passed, 22 error in 4.30 seconds ===========================
```