### PR TITLE
Relay fixture results to recursive call of 'get_features'.

### DIFF
--- a/pytest_bdd/feature.py
+++ b/pytest_bdd/feature.py
@@ -154,7 +154,12 @@ def get_features(paths, **kwargs):
         if path not in seen_names:
             seen_names.add(path)
             if op.isdir(path):
-                features.extend(get_features(glob2.iglob(op.join(path, "**", "*.feature"))))
+                features.extend(
+                    get_features(
+                        glob2.iglob(op.join(path, "**", "*.feature")),
+                        **kwargs
+                    )
+                )
             else:
                 base, name = op.split(path)
                 feature = Feature.get_feature(base, name, **kwargs)


### PR DESCRIPTION
# What this does & Why

Currently, were you to specify fixture settings that alter the behavior used when parsing tests (specifically, in my case, `pytestbdd_strict_gherkin`), those fixture settings are not passed along to the recursive call of `get_features`.  This adds that.
