### PR TITLE
Fix #210 do not raise wrong Error for no strict gherkin feature

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -19,3 +19,4 @@ These people have contributed to `pytest-bdd`, in alphabetical order:
 * `Laurence Rowe <l@lrowe.co.uk>`_
 * `Leonardo Santagada <santagada@github.com>`_
 * `Robin Pedersen <ropez@github.com>`_
+* `Sergey Kraynev <sergejyit@gmail.com>`_

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+2.18.2
+------
+
+- Fix check for out section steps definitions for no strict gherkin feature
+
 2.18.1
 ------
 

--- a/README.rst
+++ b/README.rst
@@ -884,6 +884,14 @@ steps, adding possibility to prepare some common setup for multiple scenarios in
 About background best practices, please read
 `here <https://github.com/cucumber/cucumber/wiki/Background#good-practices-for-using-background>`_.
 
+.. NOTE:: There is only step "Given" should be used in "Background" section,
+          steps "When" and "Then" are prohibited, because their purpose are
+          related to actions and consuming outcomes, that is conflict with
+          "Background" aim - prepare system for tests or "put the system
+          in a known state" as "Given" does it.
+          The statement above is applied for strict Gherkin mode, which is
+          enabled by default.
+
 
 Reusing fixtures
 ----------------

--- a/pytest_bdd/feature.py
+++ b/pytest_bdd/feature.py
@@ -293,7 +293,11 @@ class Feature(object):
                     continue
                 mode = get_step_type(clean_line) or mode
 
-                if not scenario and prev_mode not in (types.BACKGROUND, types.GIVEN) and mode in types.STEP_TYPES:
+                allowed_prev_mode = (types.BACKGROUND, types.GIVEN)
+                if not strict_gherkin:
+                    allowed_prev_mode += (types.WHEN, )
+
+                if not scenario and prev_mode not in allowed_prev_mode  and mode in types.STEP_TYPES:
                     raise exceptions.FeatureError(
                         "Step definition outside of a Scenario or a Background", line_number, clean_line, filename)
 

--- a/tests/feature/no_sctrict_gherkin_background.feature
+++ b/tests/feature/no_sctrict_gherkin_background.feature
@@ -1,0 +1,8 @@
+Feature: No strict Gherkin Background support
+
+    Background:
+        When foo has a value "bar"
+        And foo is not boolean
+        And foo has not a value "baz"
+
+    Scenario: Test background

--- a/tests/feature/no_sctrict_gherkin_scenario.feature
+++ b/tests/feature/no_sctrict_gherkin_scenario.feature
@@ -1,0 +1,6 @@
+Feature: No strict Gherkin Scenario support
+
+    Scenario: Test scenario
+        When foo has a value "bar"
+        And foo is not boolean
+        And foo has not a value "baz"

--- a/tests/feature/test_no_scenario.py
+++ b/tests/feature/test_no_scenario.py
@@ -24,3 +24,25 @@ def test_no_scenarios(testdir):
             '*FeatureError: Step definition outside of a Scenario or a Background.*',
         ],
     )
+
+
+def test_only_background_strict_mode(testdir):
+    """Test only wrong background defined in the feature file."""
+    features = testdir.mkdir('features')
+    features.join('test.feature').write_text(textwrap.dedent(u"""
+    Background:
+        Given foo
+        When bar
+    """), 'utf-8', ensure=True)
+    testdir.makepyfile(py.code.Source("""
+
+        from pytest_bdd import scenarios
+
+        scenarios('features')
+    """))
+    result = testdir.runpytest()
+    result.stdout.fnmatch_lines(
+        [
+            '*FeatureError: Background section can only contain Given steps.*',
+        ],
+    )

--- a/tests/feature/test_no_sctrict_gherkin.py
+++ b/tests/feature/test_no_sctrict_gherkin.py
@@ -1,0 +1,59 @@
+"""Test no strict gherkin for sections."""
+
+import py
+import pytest
+
+from pytest_bdd import (
+    when,
+    scenario,
+)
+
+
+@pytest.fixture
+def pytestbdd_strict_gherkin():
+    return False
+
+
+def test_background_no_strict_gherkin(request):
+    """Test background no strict gherkin."""
+    @scenario(
+        "no_sctrict_gherkin_background.feature",
+        "Test background",
+    )
+    def test():
+        pass
+
+    test(request)
+
+def test_scenario_no_strict_gherkin(request):
+    """Test scenario no strict gherkin."""
+    @scenario(
+        "no_sctrict_gherkin_scenario.feature",
+        "Test scenario",
+    )
+    def test():
+        pass
+
+    test(request)
+
+
+@pytest.fixture
+def foo():
+    return {}
+
+
+@when('foo has a value "bar"')
+def bar(foo):
+    foo["bar"] = "bar"
+    return foo["bar"]
+
+
+@when('foo is not boolean')
+def not_boolean(foo):
+    assert foo is not bool
+
+
+@when('foo has not a value "baz"')
+def has_not_baz(foo):
+    assert "baz" not in foo
+


### PR DESCRIPTION
The issue, that if user disable strict gherkin check, it will lead to
situation, when wrong Error be raised. For the current situation it was
a message, that Step is defined outside of Background section.

Current patch makes check for orphan steps more tolerant for features
without strict gherkin syntax.

Also README was updated to show explicitly, that using "When, Then" is
prohibited in "Background" section.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pytest-dev/pytest-bdd/211)
<!-- Reviewable:end -->
