### PR TITLE
Adds ability to pass custom template to the generate command

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1159,6 +1159,16 @@ It will print the generated code to the standard output so you can easily redire
 
     pytest-bdd generate features/some.feature > tests/functional/test_some.py
 
+If you want to use a custom template to generate the test file you can pass the ``--template`` parameter to the command.
+
+::
+
+    pytest-bdd generate features/some.feature --template path/to/your/template.py.mak
+
+Templates are created using mako, more information about the required syntax can be found `here <http://docs.makotemplates.org/en/latest/syntax.html>`_.
+
+
+
 
 Advanced code generation
 ------------------------

--- a/pytest_bdd/generation.py
+++ b/pytest_bdd/generation.py
@@ -15,9 +15,6 @@ from .feature import get_features
 from .types import STEP_TYPES
 
 
-template_lookup = TemplateLookup(directories=[os.path.join(os.path.dirname(__file__), "templates")])
-
-
 def add_options(parser):
     """Add pytest-bdd options."""
     group = parser.getgroup("bdd", "Generation")
@@ -45,12 +42,21 @@ def cmdline_main(config):
         return show_missing_code(config)
 
 
-def generate_code(features, scenarios, steps):
+def generate_code(features, scenarios, steps, template_path=None):
     """Generate test code for the given filenames."""
     grouped_steps = group_steps(steps)
-    template = template_lookup.get_template("test.py.mak")
-    return template.render(
-        features=features, scenarios=scenarios, steps=grouped_steps, make_python_name=make_python_name)
+    if template_path is None:
+        template_lookup = TemplateLookup(
+            directories=[os.path.join(os.path.dirname(__file__), "templates")])
+        template = template_lookup.get_template("test.py.mak")
+    else:
+        template_lookup = TemplateLookup(
+            directories=os.path.abspath(os.path.dirname(template_path)))
+        template = template_lookup.get_template(
+            os.path.split(template_path)[1])
+    return template.render(features=features, scenarios=scenarios,
+                           steps=grouped_steps,
+                           make_python_name=make_python_name)
 
 
 def show_missing_code(config):

--- a/pytest_bdd/scripts.py
+++ b/pytest_bdd/scripts.py
@@ -47,7 +47,7 @@ def check_existense(file_name):
 def print_generated_code(args):
     """Print generated test code for the given filenames."""
     features, scenarios, steps = parse_feature_files(args.files)
-    code = generate_code(features, scenarios, steps)
+    code = generate_code(features, scenarios, steps, args.template)
     print(code)
 
 
@@ -63,6 +63,12 @@ def main():
         type=check_existense,
         nargs="+",
         help="Feature files to generate test code with",
+    )
+    parser_generate.add_argument(
+        "--template",
+        metavar="TEMPLATE_FILE",
+        type=check_existense,
+        help="Template file to use when generating test code"
     )
     parser_generate.set_defaults(func=print_generated_code)
 

--- a/tests/scripts/other_template.py.mak
+++ b/tests/scripts/other_template.py.mak
@@ -1,0 +1,27 @@
+% if features:
+"""${ features[0].name } feature tests generated with an alternative template."""
+from pytest_bdd import given, then, when
+
+from my_helpers import set_full_scenario_path
+
+
+scenario = set_full_scenario_path('${features[0].rel_filename}')
+
+
+% endif
+% for scenario in sorted(scenarios, key=lambda scenario: scenario.name):
+@scenario('${scenario.name}')
+def test_${ make_python_name(scenario.name)}():
+    pass
+
+
+% endfor
+% for step in steps:
+@${step.type}('${step.name}')
+def ${ make_python_name(step.name)}():
+    pass
+% if not loop.last:
+
+
+% endif
+% endfor

--- a/tests/scripts/test_generate.py
+++ b/tests/scripts/test_generate.py
@@ -50,3 +50,47 @@ def test_generate(monkeypatch, capsys):
         """my list should be [1]."""
 
     '''[1:].replace(u"'", u"'"))
+
+
+def test_generate_with_custom_template(monkeypatch, capsys):
+    monkeypatch.setattr(
+        sys, 'argv',
+        ['', 'generate', os.path.join(PATH, 'generate.feature'),
+         '--template', os.path.join(PATH, 'other_template.py.mak')])
+    main()
+    out, err = capsys.readouterr()
+    assert out == textwrap.dedent('''
+    """Code generation feature tests generated with an alternative template."""
+    from pytest_bdd import given, then, when
+
+    from my_helpers import set_full_scenario_path
+
+
+    scenario = set_full_scenario_path('scripts/generate.feature')
+
+
+    @scenario('Given and when using the same fixture should not evaluate it twice')
+    def test_given_and_when_using_the_same_fixture_should_not_evaluate_it_twice():
+        pass
+
+
+    @given('1 have a fixture (appends 1 to a list) in reuse syntax')
+    def have_a_fixture_appends_1_to_a_list_in_reuse_syntax():
+        pass
+
+
+    @given('I have an empty list')
+    def i_have_an_empty_list():
+        pass
+
+
+    @when('I use this fixture')
+    def i_use_this_fixture():
+        pass
+
+
+    @then('my list should be [1]')
+    def my_list_should_be_1():
+        pass
+
+    '''[1:].replace(u"'", u"'"))


### PR DESCRIPTION
The generate option can be a great time saver, but it would really help me if I could use a custom template not the default one, that way I can configure it to save me the most time possible.

I've added a test which uses a new custom template and made a note about using it in the docs, but let me know if you think this needs anything else. 