### PR TITLE
Fix #202: replace step parameters by their values in --gherkin-terminal-reporter output

### DIFF
--- a/pytest_bdd/reporting.py
+++ b/pytest_bdd/reporting.py
@@ -6,6 +6,8 @@ that enriches the pytest test reporting.
 
 import time
 
+from .feature import force_unicode
+
 
 class StepReport(object):
 
@@ -60,7 +62,7 @@ class StepReport(object):
 
 class ScenarioReport(object):
 
-    """Scenario excecution report."""
+    """Scenario execution report."""
 
     def __init__(self, scenario, node):
         """Scenario report constructor.
@@ -81,6 +83,10 @@ class ScenarioReport(object):
                 self.param_index = param_values.index(node_param_values)
             elif tuple(node_param_values) in param_values:
                 self.param_index = param_values.index(tuple(node_param_values))
+        self.example_kwargs = {
+            example_param: force_unicode(node.funcargs[example_param])
+            for example_param in scenario.get_example_params()
+        }
 
     @property
     def current_step_report(self):
@@ -129,7 +135,8 @@ class ScenarioReport(object):
                     "rows": params,
                     "row_index": self.param_index,
                 }
-            ] if scenario.examples else []
+            ] if scenario.examples else [],
+            "example_kwargs": self.example_kwargs,
         }
 
     def fail(self):

--- a/tests/feature/gherkin_terminal_reporter.feature
+++ b/tests/feature/gherkin_terminal_reporter.feature
@@ -40,3 +40,8 @@ Feature: Gherkin terminal reporter
     Given there is gherkin scenario with broken implementation
     When tests are run with --showlocals
     Then error traceback contains local variable descriptions
+
+  Scenario: Should step parameters be replaced by their values
+    Given there is gherkin scenario outline implemented
+    When tests are run with step expanded mode
+    Then output must contain parameters values

--- a/tests/feature/test_report.py
+++ b/tests/feature/test_report.py
@@ -109,7 +109,8 @@ def test_step_trace(testdir):
                            'name': u'some other passing step',
                            'type': 'given'}],
                 'tags': [u'scenario-passing-tag'],
-                'examples': []}
+                'examples': [],
+                'example_kwargs': {}}
 
     assert report == expected
 
@@ -135,7 +136,8 @@ def test_step_trace(testdir):
                            'name': u'a failing step',
                            'type': 'given'}],
                 'tags': [u'scenario-failing-tag'],
-                'examples': []}
+                'examples': [],
+                'example_kwargs': {}}
     assert report == expected
 
     report = result.matchreport('test_outlined[12-5.0-7]', when='call').scenario
@@ -171,6 +173,7 @@ def test_step_trace(testdir):
                               'row_index': 0,
                               'rows': [['start', 'eat', 'left'],
                                        [[12, 5.0, '7'], [5, 4.0, '1']]]}],
+                'example_kwargs': {'eat': '5.0', 'left': '7', 'start': '12'},
                 }
     assert report == expected
 
@@ -207,6 +210,7 @@ def test_step_trace(testdir):
                               'row_index': 1,
                               'rows': [['start', 'eat', 'left'],
                                        [[12, 5.0, '7'], [5, 4.0, '1']]]}],
+                'example_kwargs': {'eat': '4.0', 'left': '1', 'start': '5'},
                 }
     assert report == expected
 


### PR DESCRIPTION
Fix #202. The output with real values from examples looks much nicer.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pytest-dev/pytest-bdd/222)
<!-- Reviewable:end -->
