### PR TITLE
Fill in step names in cucumber report.

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -18,5 +18,6 @@ These people have contributed to `pytest-bdd`, in alphabetical order:
 * `Harro van der Klauw <hvdklauw@gmail.com>`_
 * `Laurence Rowe <l@lrowe.co.uk>`_
 * `Leonardo Santagada <santagada@github.com>`_
+* `Michiel Holtkamp <github@elfstone.nl>`_
 * `Robin Pedersen <ropez@github.com>`_
 * `Sergey Kraynev <sergejyit@gmail.com>`_

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+2.19.0
+------
+
+- Added --cucumber-json-expanded option for explicit selection of expanded format (mjholtkamp)
+- Step names are filled in when --cucumber-json-expanded is used (mjholtkamp)
+
 2.18.2
 ------
 

--- a/README.rst
+++ b/README.rst
@@ -1133,6 +1133,12 @@ To have an output in json format:
 
     py.test --cucumberjson=<path to json report>
 
+This will output an expanded (meaning scenario outlines will be expanded to several scenarios) cucumber format.
+To also fill in parameters in the step name, you have to explicitly tell pytest-bdd to use the expanded format:
+
+::
+
+    py.test --cucumberjson=<path to json report> --cucumberjson-expanded
 
 To enable gherkin-formatted output on terminal, use
 


### PR DESCRIPTION
According to [1], when the outline scenarios are
reported in 'expand' mode, all the outlines will
be expanded to scenarios with their test results.
Also, the step name parameters are filled in.

This is a different mode than without 'expand'
mode[2], where the scenario outlines are reported
so the step names are not filled in and there are
no test results. The "examples" are reported in
this mode.

Since pytest-bdd does report the results of each
step of an outline scenario as separate scenarios,
it looks more like the 'expand' mode, so I've
added the filling in of the parameters in the
step names to make it more compliant.


[1] https://relishapp.com/cucumber/cucumber/docs/formatters/json-output-formatter#scenario-outline-expanded
[2] https://relishapp.com/cucumber/cucumber/docs/formatters/json-output-formatter#scenario-outline

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pytest-dev/pytest-bdd/227)
<!-- Reviewable:end -->
