### PR TITLE
Fixes #201 and pytest compatibility.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,15 @@
 Changelog
 =========
 
+
+2.20.0
+------
+
+- Added support for But steps (olegpidsadnyi)
+- Fixed compatibility with pytest 3.3.2 (olegpidsadnyi)
+- MInimal required version of pytest is now 2.8.1 since it doesn't support earlier versions (olegpidsadnyi)
+
+
 2.19.0
 ------
 

--- a/README.rst
+++ b/README.rst
@@ -35,6 +35,9 @@ Install pytest-bdd
     pip install pytest-bdd
 
 
+The minimal required version of pytest is 2.8.1.
+
+
 Example
 -------
 

--- a/pytest_bdd/__init__.py
+++ b/pytest_bdd/__init__.py
@@ -3,6 +3,6 @@
 from pytest_bdd.steps import given, when, then
 from pytest_bdd.scenario import scenario, scenarios
 
-__version__ = '2.19.0'
+__version__ = '2.20.0'
 
 __all__ = [given.__name__, when.__name__, then.__name__, scenario.__name__, scenarios.__name__]

--- a/pytest_bdd/feature.py
+++ b/pytest_bdd/feature.py
@@ -52,8 +52,9 @@ STEP_PREFIXES = [
     ("When ", types.WHEN),
     ("Then ", types.THEN),
     ("@", types.TAG),
-    ("And ", None),  # Unknown step type,
-    ("But ", None),  # Unknown step type,
+    # Continuation of the previously mentioned step type
+    ("And ", None),
+    ("But ", None),
 ]
 
 STEP_PARAM_RE = re.compile("\<(.+?)\>")

--- a/pytest_bdd/feature.py
+++ b/pytest_bdd/feature.py
@@ -53,6 +53,7 @@ STEP_PREFIXES = [
     ("Then ", types.THEN),
     ("@", types.TAG),
     ("And ", None),  # Unknown step type,
+    ("But ", None),  # Unknown step type,
 ]
 
 STEP_PARAM_RE = re.compile("\<(.+?)\>")
@@ -297,7 +298,7 @@ class Feature(object):
                 if not strict_gherkin:
                     allowed_prev_mode += (types.WHEN, )
 
-                if not scenario and prev_mode not in allowed_prev_mode  and mode in types.STEP_TYPES:
+                if not scenario and prev_mode not in allowed_prev_mode and mode in types.STEP_TYPES:
                     raise exceptions.FeatureError(
                         "Step definition outside of a Scenario or a Background", line_number, clean_line, filename)
 

--- a/pytest_bdd/steps.py
+++ b/pytest_bdd/steps.py
@@ -304,15 +304,18 @@ def inject_fixture(request, arg, value):
     fd.cached_result = (value, 0, None)
 
     old_fd = get_request_fixture_defs(request).get(arg)
-    old_value = get_fixture_value_raw(request, arg)
     add_fixturename = arg not in request.fixturenames
+
+    old_value = get_fixture_value_raw(request, arg)  # Compatibility with pytest < 3.3.2
 
     def fin():
         request._fixturemanager._arg2fixturedefs[arg].remove(fd)
         get_request_fixture_defs(request)[arg] = old_fd
-        set_fixture_value(request, arg, old_value)
+
         if add_fixturename:
             get_request_fixture_names(request).remove(arg)
+
+        set_fixture_value(request, arg, old_value)  # Compatibility with pytest < 3.3.2
 
     request.addfinalizer(fin)
 

--- a/pytest_bdd/utils.py
+++ b/pytest_bdd/utils.py
@@ -37,19 +37,31 @@ def get_fixture_value(request, name):
 
 
 def get_fixture_value_raw(request, name):
-    """Set the given raw fixture value from the pytest request object."""
+    """Set the given raw fixture value from the pytest request object.
+
+    :note: Compatibility with pytest < 3.3.2
+    """
     try:
         return request._fixture_values.get(name)
     except AttributeError:
-        return request._funcargs.get(name)
+        try:
+            return request._funcargs.get(name)
+        except AttributeError:
+            pass
 
 
 def set_fixture_value(request, name, value):
-    """Set the given fixture value on the pytest request object."""
+    """Set the given fixture value on the pytest request object.
+
+    :note: Compatibility with pytest < 3.3.2
+    """
     try:
         request._fixture_values[name] = value
     except AttributeError:
-        request._funcargs[name] = value
+        try:
+            request._funcargs[name] = value
+        except AttributeError:
+            pass
 
 
 def get_request_fixture_defs(request):

--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ setup(
         "Mako",
         "parse",
         "parse_type",
-        "pytest>=2.6.0",
+        "pytest>=2.8.1",
         "six>=1.9.0",
     ],
     # the following makes a plugin available to py.test

--- a/tests/feature/steps.feature
+++ b/tests/feature/steps.feature
@@ -10,7 +10,7 @@ Scenario: Executed step by step
     And I append 2 to the list
     And I append 3 to the list
     Then foo should have value "foo"
-    And the list should be [1, 2, 3]
+    But the list should be [1, 2, 3]
 
 
 Scenario: When step can be the first

--- a/tests/feature/test_scenarios.py
+++ b/tests/feature/test_scenarios.py
@@ -4,6 +4,10 @@ import textwrap
 
 def test_scenarios(testdir):
     """Test scenarios shortcut."""
+    testdir.makeini("""
+            [pytest]
+            console_output_style=classic
+        """)
     testdir.makeconftest("""
         import pytest
         from pytest_bdd import given

--- a/tests/feature/test_steps.py
+++ b/tests/feature/test_steps.py
@@ -195,6 +195,11 @@ def test_step_hooks(testdir):
 
 def test_step_trace(testdir):
     """Test step trace."""
+    testdir.makeini("""
+        [pytest]
+        console_output_style=classic
+    """)
+
     testdir.makefile('.feature', test="""
     Scenario: When step has failure
         Given I have a bar

--- a/tests/steps/test_given.py
+++ b/tests/steps/test_given.py
@@ -9,6 +9,7 @@ from pytest_bdd.steps import StepError
 def foo():
     return "foo"
 
+
 given("I have alias for foo", fixture="foo")
 given("I have an alias to the root fixture", fixture="root")
 


### PR DESCRIPTION
1. Pytest 3.3.2 has removed request._fixture_values, so ignoring AttributeError should be a solution. I guess replacing a FixtureDef with the cached_result will do the inject_fixture job.
2. There were compatibility issues introduced since pytest 2.8, and there's a change in the names of the parametrized items which breaks pytest-bdd tests. Let's support 2.8.1 as a minimal version then.
3. But keyword support added.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pytest-dev/pytest-bdd/232)
<!-- Reviewable:end -->
