### PR TITLE
Update lowest required pytest version

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+3.0.1
+------
+
+- Minimal supported version of `pytest` is now 2.9.0 as lower versions do not support `bool` type ini options (sliwinski-milosz) #260
+
 3.0.0
 ------
 

--- a/pytest_bdd/__init__.py
+++ b/pytest_bdd/__init__.py
@@ -3,6 +3,6 @@
 from pytest_bdd.steps import given, when, then
 from pytest_bdd.scenario import scenario, scenarios
 
-__version__ = '3.0.0'
+__version__ = '3.0.1'
 
 __all__ = [given.__name__, when.__name__, then.__name__, scenario.__name__, scenarios.__name__]

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ setup(
         "parse",
         "parse_type",
         "py",
-        "pytest>=2.8.1",
+        "pytest>=2.9.0",
         "six>=1.9.0",
     ],
     # the following makes a plugin available to py.test

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 distshare={homedir}/.tox/distshare
 #envlist=linters,py27,py27-xdist,py27-pytest-latest,py34
-envlist=linters,py27,py27-pytest-latest,py34
+envlist=linters,py27,py27-pytest-minimal,py27-pytest-latest,py34
 skip_missing_interpreters = true
 
 [testenv]
@@ -24,6 +24,13 @@ deps =
     {[testenv]deps}
     git+https://github.com/pytest-dev/py#egg=py
     git+https://github.com/pytest-dev/pytest.git@features#egg=pytest
+
+[testenv:py27-pytest-minimal]
+basepython=python2.7
+deps =
+    pytest==2.9.0
+    pytest-xdist==1.17
+    mock
 
 [testenv:coveralls]
 passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH


### PR DESCRIPTION
We use `bool` type ini option for `bdd_strict_gherkin`.

Support for that type has been added to `Parser.addini` starting from `pytest==2.9.0`.
https://docs.pytest.org/en/latest/changelog.html#id625

Due to above `pytest==2.9.0` is the lowest version that latest `pytest-bdd` can work with.

For testing with `pytest==2.9.0` you have to use `pytest-xdist<=1.17` as newer `pytest-xdist` requires `pytest>=3.0.0`.