### PR TITLE
Do not use deprecated MarkInfo objects on pytest>=3.6

### DIFF
--- a/pytest_bdd/reporting.py
+++ b/pytest_bdd/reporting.py
@@ -7,6 +7,7 @@ that enriches the pytest test reporting.
 import time
 
 from .feature import force_unicode
+from .utils import get_closest_marker_args
 
 
 class StepReport(object):
@@ -73,11 +74,11 @@ class ScenarioReport(object):
         self.scenario = scenario
         self.step_reports = []
         self.param_index = None
-        parametrize = node.keywords._markers.get('parametrize')
-        if parametrize and scenario.examples:
-            param_names = parametrize.args[0] if isinstance(parametrize.args[0], (tuple, list)) else [
-                parametrize.args[0]]
-            param_values = parametrize.args[1]
+        parametrize_args = get_closest_marker_args(node, 'parametrize')
+        if parametrize_args and scenario.examples:
+            param_names = parametrize_args[0] if isinstance(parametrize_args[0], (tuple, list)) else [
+                parametrize_args[0]]
+            param_values = parametrize_args[1]
             node_param_values = [node.funcargs[param_name] for param_name in param_names]
             if node_param_values in param_values:
                 self.param_index = param_values.index(node_param_values)

--- a/pytest_bdd/utils.py
+++ b/pytest_bdd/utils.py
@@ -84,3 +84,27 @@ def get_request_fixture_names(request):
     Compatibility with pytest 3.0.
     """
     return request._pyfuncitem._fixtureinfo.names_closure
+
+
+def get_closest_marker_args(node, mark_name):
+    """In pytest 3.6 new API to access markers has been introduced and it deprecated
+    MarkInfo objects.
+
+    This function uses that API if it is available otherwise it uses MarkInfo objects.
+    """
+    try:
+        return get_closest_marker_args_using_get_closest_marker(node, mark_name)
+    except AttributeError:
+        return get_closest_marker_args_using_mark_objects(node, mark_name)
+
+
+def get_closest_marker_args_using_get_closest_marker(node, mark_name):
+    """Recommended on pytest>=3.6"""
+    marker = node.get_closest_marker(mark_name)
+    return marker.args if marker else None
+
+
+def get_closest_marker_args_using_mark_objects(node, mark_name):
+    """Deprecated on pytest>=3.6"""
+    marker = node.keywords._markers.get(mark_name)
+    return (marker.args[0], marker.args[1]) if marker else None

--- a/tests/feature/test_outline.py
+++ b/tests/feature/test_outline.py
@@ -6,6 +6,7 @@ import pytest
 
 from pytest_bdd import given, when, then, scenario
 from pytest_bdd import exceptions
+from tests.utils import get_parametrize_markers_args
 
 
 @scenario(
@@ -13,8 +14,8 @@ from pytest_bdd import exceptions
     'Outlined given, when, thens',
     example_converters=dict(start=int, eat=float, left=str)
 )
-def test_outlined():
-    assert test_outlined.parametrize.args == (
+def test_outlined(request):
+    assert get_parametrize_markers_args(request.node) == (
         [u'start', u'eat', u'left'], [[12, 5.0, '7'], [5, 4.0, '1']])
 
 
@@ -133,9 +134,9 @@ def test_outlined_with_other_fixtures(other_fixture):
     'Outlined with vertical example table',
     example_converters=dict(start=int, eat=float, left=str)
 )
-def test_vertical_example():
+def test_vertical_example(request):
     """Test outlined scenario with vertical examples table."""
-    assert test_vertical_example.parametrize.args == (
+    assert get_parametrize_markers_args(request.node) == (
         [u'start', u'eat', u'left'], [[12, 5.0, '7'], [2, 1.0, '1']])
 
 
@@ -187,8 +188,8 @@ def should_have_left_fruits(start_fruits, start, eat, left, fruits):
     'Outlined given, when, thens',
     example_converters=dict(start=int, eat=float, left=str)
 )
-def test_outlined_feature():
-    assert test_outlined_feature.parametrize.args == (
+def test_outlined_feature(request):
+    assert get_parametrize_markers_args(request.node) == (
         ['start', 'eat', 'left'],
         [[12, 5.0, '7'], [5, 4.0, '1']],
         ['fruits'],

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,19 @@
+def get_parametrize_markers_args(node):
+    mark_name = 'parametrize'
+    try:
+        return get_markers_args_using_iter_markers(node, mark_name)
+    except AttributeError:
+        return get_markers_args_using_mark_objects(node, mark_name)
+
+
+def get_markers_args_using_iter_markers(node, mark_name):
+    """Recommended on pytest>=3.6"""
+    args = []
+    for mark in node.iter_markers(mark_name):
+        args += mark.args
+    return tuple(args)
+
+
+def get_markers_args_using_mark_objects(node, mark_name):
+    """Deprecated on pytest>=3.6"""
+    return getattr(node.keywords._markers.get(mark_name), 'args', ())


### PR DESCRIPTION
Fixes https://github.com/pytest-dev/pytest-bdd/issues/261

Please note that new `get_closest_marker_args` function returns the same args on all supported `pytest` versions.

I fixed 3 test cases however I do not know how to get rid of the warning in following one (if it is even possible):
`tests/feature/test_outline.py::test_empty_example_values`