### PR TITLE
Let gherkin-terminal-reporter-expanded enable gherkin output

### DIFF
--- a/pytest_bdd/cucumber_json.py
+++ b/pytest_bdd/cucumber_json.py
@@ -32,7 +32,7 @@ def add_options(parser):
         "--cucumberjson-expanded",
         "--cucumber-json-expanded",
         action="store_true",
-        dest="expand",
+        dest="cucumber_json_expanded",
         default=False,
         help="expand scenario outlines into scenarios and fill in the step names",
     )
@@ -42,7 +42,7 @@ def configure(config):
     cucumber_json_path = config.option.cucumber_json_path
     # prevent opening json log on slave nodes (xdist)
     if cucumber_json_path and not hasattr(config, "slaveinput"):
-        config._bddcucumberjson = LogBDDCucumberJSON(cucumber_json_path, expand=config.option.expand)
+        config._bddcucumberjson = LogBDDCucumberJSON(cucumber_json_path, expand=config.option.cucumber_json_expanded)
         config.pluginmanager.register(config._bddcucumberjson)
 
 

--- a/pytest_bdd/gherkin_terminal_reporter.py
+++ b/pytest_bdd/gherkin_terminal_reporter.py
@@ -104,8 +104,8 @@ class GherkinTerminalReporter(TerminalReporter):
                         step_name = self._format_step_name(step['name'], **report.scenario['example_kwargs'])
                     else:
                         step_name = step['name']
-                    self._tw.write('        {} {}\n'.format(step['keyword'],
-                                                            step_name), **scenario_markup)
+                    self._tw.write(u'        {} {}\n'.format(step['keyword'],
+                                                             step_name), **scenario_markup)
                 self._tw.write('    ' + word, **word_markup)
                 self._tw.write('\n\n')
             else:

--- a/pytest_bdd/gherkin_terminal_reporter.py
+++ b/pytest_bdd/gherkin_terminal_reporter.py
@@ -21,14 +21,14 @@ def add_options(parser):
     group._addoption(
         "--gherkin-terminal-reporter-expanded",
         action="store_true",
-        dest="expand",
+        dest="gherkin_expanded",
         default=False,
-        help="expand scenario outlines into scenarios and fill in the step names",
+        help="enable gherkin output, expand scenario outlines into scenarios and fill in the step names",
     )
 
 
 def configure(config):
-    if config.option.gherkin_terminal_reporter:
+    if config.option.gherkin_terminal_reporter or config.option.gherkin_expanded:
         # Get the standard terminal reporter plugin and replace it with our
         current_reporter = config.pluginmanager.getplugin('terminalreporter')
         if current_reporter.__class__ != TerminalReporter:
@@ -100,7 +100,7 @@ class GherkinTerminalReporter(TerminalReporter):
                 self._tw.write(report.scenario['name'], **scenario_markup)
                 self._tw.write('\n')
                 for step in report.scenario['steps']:
-                    if self.config.option.expand:
+                    if self.config.option.gherkin_expanded:
                         step_name = self._format_step_name(step['name'], **report.scenario['example_kwargs'])
                     else:
                         step_name = step['name']

--- a/pytest_bdd/utils.py
+++ b/pytest_bdd/utils.py
@@ -113,9 +113,9 @@ def get_markers_args_using_get_marker(node, mark_name):
 
 
 def get_parametrize_params(parametrize_args):
-    """Group parametrize markers arugments names and values.
+    """Group parametrize markers arguments names and values.
 
-    :param marker_args: json-serialized `Scenario` or `Feature`.
+    :param parametrize_args: parametrize markers arguments.
     :return: `list` of `dict` in the form of:
         [
             {

--- a/pytest_bdd/utils.py
+++ b/pytest_bdd/utils.py
@@ -110,3 +110,33 @@ def get_markers_args_using_iter_markers(node, mark_name):
 def get_markers_args_using_get_marker(node, mark_name):
     """Deprecated on pytest>=3.6"""
     return getattr(node.get_marker(mark_name), 'args', ())
+
+
+def get_parametrize_params(parametrize_args):
+    """Group parametrize markers arugments names and values.
+
+    :param marker_args: json-serialized `Scenario` or `Feature`.
+    :return: `list` of `dict` in the form of:
+        [
+            {
+                "names": ["name1", "name2", ...],
+                "values": [value1, value2, ...],
+            },
+            ...
+        ]
+    """
+    params = []
+    for i in range(0, len(parametrize_args), 2):
+        params.append({
+            'names': _get_param_names(parametrize_args[i]),
+            'values': parametrize_args[i+1]
+        })
+    return params
+
+
+def _get_param_names(names):
+    if not isinstance(names, (tuple, list)):
+        # As pytest.mark.parametrize has only one param name,
+        # it is not returned as a list. Convert it to list:
+        names = [names]
+    return names

--- a/tests/feature/gherkin_terminal_reporter.feature
+++ b/tests/feature/gherkin_terminal_reporter.feature
@@ -43,5 +43,10 @@ Feature: Gherkin terminal reporter
 
   Scenario: Should step parameters be replaced by their values
     Given there is gherkin scenario outline implemented
-    When tests are run with step expanded mode
+    When tests are run with step expanded option
+    Then output must contain parameters values
+
+  Scenario: Should step parameters be replaced by their values also when used together with gherkin reporter option
+    Given there is gherkin scenario outline implemented
+    When tests are run with step expanded and gherkin reporter options
     Then output must contain parameters values

--- a/tests/feature/outline_feature.feature
+++ b/tests/feature/outline_feature.feature
@@ -4,6 +4,7 @@ Feature: Outline
     | start | eat | left |
     |  12   |  5  |  7   |
     |  5    |  4  |  1   |
+    |  4    |  2  |  2   |
 
     Scenario Outline: Outlined given, when, thens
         Given there are <start> <fruits>

--- a/tests/feature/parametrized.feature
+++ b/tests/feature/parametrized.feature
@@ -2,3 +2,7 @@ Scenario: Parametrized given, when, thens
     Given there are <start> cucumbers
     When I eat <eat> cucumbers
     Then I should have <left> cucumbers
+
+
+Scenario: Parametrized given - single param
+    Given there are <start> cucumbers

--- a/tests/feature/test_gherkin_terminal_reporter.py
+++ b/tests/feature/test_gherkin_terminal_reporter.py
@@ -60,6 +60,12 @@ def test_Should_step_parameters_be_replaced_by_their_values():
     pass
 
 
+@scenario('gherkin_terminal_reporter.feature',
+          'Should step parameters be replaced by their values also when used together with gherkin reporter option')
+def test_Should_step_parameters_be_replaced_by_their_values_also_when_used_together_with_gherkin_reporter_option():
+    pass
+
+
 @pytest.fixture(params=[0, 1, 2],
                 ids=['compact mode', 'line per test', 'verbose'])
 def verbosity_mode(request):
@@ -184,8 +190,17 @@ def tests_are_run_with_very_verbose_mode(testdir, test_execution):
     test_execution['gherkin'] = testdir.runpytest('--gherkin-terminal-reporter', '-vv')
 
 
-@when("tests are run with step expanded mode")
-def tests_are_run_with_step_expanded_mode(testdir, test_execution):
+@when("tests are run with step expanded option")
+def tests_are_run_with_step_expanded_option(testdir, test_execution):
+    test_execution['regular'] = testdir.runpytest('-vv')
+    test_execution['gherkin'] = testdir.runpytest(
+        '--gherkin-terminal-reporter-expanded',
+        '-vv',
+    )
+
+
+@when("tests are run with step expanded and gherkin reporter options")
+def tests_are_run_with_step_expanded_and_gherkin_reporter_options(testdir, test_execution):
     test_execution['regular'] = testdir.runpytest('-vv')
     test_execution['gherkin'] = testdir.runpytest(
         '--gherkin-terminal-reporter',

--- a/tests/feature/test_outline.py
+++ b/tests/feature/test_outline.py
@@ -168,7 +168,7 @@ def should_have_left_fruits(start_fruits, start, eat, left, fruits):
 def test_outlined_feature(request):
     assert get_parametrize_markers_args(request.node) == (
         ['start', 'eat', 'left'],
-        [[12, 5.0, '7'], [5, 4.0, '1']],
+        [[12, 5.0, '7'], [5, 4.0, '1'], [4, 2.0, '2']],
         ['fruits'],
         [[u'oranges'], [u'apples']]
     )

--- a/tests/feature/test_parametrized.py
+++ b/tests/feature/test_parametrized.py
@@ -14,6 +14,17 @@ def test_parametrized(request, start, eat, left):
     """Test parametrized scenario."""
 
 
+@pytest.mark.parametrize(
+    'start', [12]
+)
+@scenario(
+    'parametrized.feature',
+    'Parametrized given - single param',
+)
+def test_parametrized_single_param(request, start):
+    """Test parametrized scenario."""
+
+
 @pytest.fixture(params=[1, 2])
 def foo_bar(request):
     return 'bar' * request.param


### PR DESCRIPTION
Related to:
https://github.com/pytest-dev/pytest-bdd/issues/247
https://github.com/pytest-dev/pytest-bdd/issues/235

This pull request updates `--gherkin-terminal-reporter-expanded` to enable gherkin output.
Thanks to that it can be used without adding `--gherkin-terminal-reporter` to the command.

This is the way suggested in the docs:
`https://pytest-bdd.readthedocs.io/en/latest/#reporting`