### PR TITLE
Fixes #271: Use parametrize markers params for getting example_kwargs

### DIFF
--- a/pytest_bdd/utils.py
+++ b/pytest_bdd/utils.py
@@ -110,3 +110,33 @@ def get_markers_args_using_iter_markers(node, mark_name):
 def get_markers_args_using_get_marker(node, mark_name):
     """Deprecated on pytest>=3.6"""
     return getattr(node.get_marker(mark_name), 'args', ())
+
+
+def get_parametrize_params(parametrize_args):
+    """Group parametrize markers arguments names and values.
+
+    :param parametrize_args: parametrize markers arguments.
+    :return: `list` of `dict` in the form of:
+        [
+            {
+                "names": ["name1", "name2", ...],
+                "values": [value1, value2, ...],
+            },
+            ...
+        ]
+    """
+    params = []
+    for i in range(0, len(parametrize_args), 2):
+        params.append({
+            'names': _get_param_names(parametrize_args[i]),
+            'values': parametrize_args[i+1]
+        })
+    return params
+
+
+def _get_param_names(names):
+    if not isinstance(names, (tuple, list)):
+        # As pytest.mark.parametrize has only one param name,
+        # it is not returned as a list. Convert it to list:
+        names = [names]
+    return names

--- a/tests/feature/outline_feature.feature
+++ b/tests/feature/outline_feature.feature
@@ -4,6 +4,7 @@ Feature: Outline
     | start | eat | left |
     |  12   |  5  |  7   |
     |  5    |  4  |  1   |
+    |  4    |  2  |  2   |
 
     Scenario Outline: Outlined given, when, thens
         Given there are <start> <fruits>

--- a/tests/feature/parametrized.feature
+++ b/tests/feature/parametrized.feature
@@ -2,3 +2,7 @@ Scenario: Parametrized given, when, thens
     Given there are <start> cucumbers
     When I eat <eat> cucumbers
     Then I should have <left> cucumbers
+
+
+Scenario: Parametrized given - single param
+    Given there are <start> cucumbers

--- a/tests/feature/test_outline.py
+++ b/tests/feature/test_outline.py
@@ -168,7 +168,7 @@ def should_have_left_fruits(start_fruits, start, eat, left, fruits):
 def test_outlined_feature(request):
     assert get_parametrize_markers_args(request.node) == (
         ['start', 'eat', 'left'],
-        [[12, 5.0, '7'], [5, 4.0, '1']],
+        [[12, 5.0, '7'], [5, 4.0, '1'], [4, 2.0, '2']],
         ['fruits'],
         [[u'oranges'], [u'apples']]
     )

--- a/tests/feature/test_parametrized.py
+++ b/tests/feature/test_parametrized.py
@@ -14,6 +14,17 @@ def test_parametrized(request, start, eat, left):
     """Test parametrized scenario."""
 
 
+@pytest.mark.parametrize(
+    'start', [12]
+)
+@scenario(
+    'parametrized.feature',
+    'Parametrized given - single param',
+)
+def test_parametrized_single_param(request, start):
+    """Test parametrized scenario."""
+
+
 @pytest.fixture(params=[1, 2])
 def foo_bar(request):
     return 'bar' * request.param


### PR DESCRIPTION
Fixes https://github.com/pytest-dev/pytest-bdd/issues/271

User can parametrize scenario by using examples specified in feature files. In that case pytest `parametrize` marker is updated with examples parameters.

We also provide a way to parametrize scenario on the python side by using `pytest.mark.parametrize`. https://pytest-bdd.readthedocs.io/en/latest/#combine-scenario-outline-and-pytest-parametrization 

The problem with gherkin reporting is that when we are getting `self.example_kwargs`, we are using `scenario.get_example_params()` method that takes into account only args that are defined inside feature file (examples), and skips `pytest.mark.parametrize` parameters.

For gherkin reporting we need all parameters: those specified in feature files and those specified by using `pytest.mark.parametrize` decorator.

This pull requests uses `parametrize` marker to get all args.