### PR TITLE
Fixes #276: configure and unconfigure Feature class

### DIFF
--- a/pytest_bdd/feature.py
+++ b/pytest_bdd/feature.py
@@ -143,7 +143,7 @@ def get_tags(line):
     )
 
 
-def get_features(paths, caller_module, **kwargs):
+def get_features(paths, **kwargs):
     """Get features for given paths.
 
     :param list paths: `list` of paths (file or dirs)
@@ -159,13 +159,12 @@ def get_features(paths, caller_module, **kwargs):
                 features.extend(
                     get_features(
                         glob2.iglob(op.join(path, "**", "*.feature")),
-                        caller_module,
                         **kwargs
                     )
                 )
             else:
                 base, name = op.split(path)
-                feature = Feature.get_feature(base, name, caller_module, **kwargs)
+                feature = Feature.get_feature(name, base, **kwargs)
                 features.append(feature)
     features.sort(key=lambda feature: feature.name or feature.filename)
     return features
@@ -406,7 +405,7 @@ class Feature(object):
             cls.strict_gherkin = None
 
     @classmethod
-    def get_feature(cls, base_dir, filename, caller_module, encoding="utf-8", strict_gherkin=True):
+    def get_feature(cls, filename, base_dir=None, caller_module=None, strict_gherkin=True, encoding="utf-8"):
         """Get a feature by the filename.
 
         :param str base_path: Base feature directory.

--- a/pytest_bdd/feature.py
+++ b/pytest_bdd/feature.py
@@ -408,12 +408,12 @@ class Feature(object):
     def get_feature(cls, filename, base_dir=None, caller_module=None, strict_gherkin=True, encoding="utf-8"):
         """Get a feature by the filename.
 
-        :param str base_path: Base feature directory.
         :param str filename: Filename of the feature file.
+        :param str base_dir: Base feature directory.
         :param module caller_module
-        :param str encoding: Feature file encoding.
         :param bool strict_gherkin: Flag whether it's a strictly gherkin scenario or not (e.g. it will validate correct
             gherkin language (given-when-then))
+        :param str encoding: Feature file encoding.
 
         :return: `Feature` instance from the parsed feature cache.
 

--- a/pytest_bdd/generation.py
+++ b/pytest_bdd/generation.py
@@ -131,7 +131,7 @@ def parse_feature_files(paths):
     :return: `list` of `tuple` in form:
              (`list` of `Feature` objects, `list` of `Scenario` objects, `list` of `Step` objects).
     """
-    features = get_features(paths, None)
+    features = get_features(paths)
     scenarios = sorted(
         itertools.chain.from_iterable(feature.scenarios.values() for feature in features),
         key=lambda scenario: (

--- a/pytest_bdd/generation.py
+++ b/pytest_bdd/generation.py
@@ -131,7 +131,7 @@ def parse_feature_files(paths):
     :return: `list` of `tuple` in form:
              (`list` of `Feature` objects, `list` of `Scenario` objects, `list` of `Step` objects).
     """
-    features = get_features(paths)
+    features = get_features(paths, None)
     scenarios = sorted(
         itertools.chain.from_iterable(feature.scenarios.values() for feature in features),
         key=lambda scenario: (

--- a/pytest_bdd/plugin.py
+++ b/pytest_bdd/plugin.py
@@ -7,6 +7,8 @@ from . import cucumber_json
 from . import generation
 from . import reporting
 from . import gherkin_terminal_reporter
+from .feature import Feature
+from .utils import ConfigStack
 
 
 def pytest_addhooks(pluginmanager):
@@ -47,13 +49,18 @@ def add_bdd_ini(parser):
 @pytest.mark.trylast
 def pytest_configure(config):
     """Configure all subplugins."""
+    ConfigStack.add(config)
     cucumber_json.configure(config)
     gherkin_terminal_reporter.configure(config)
+    Feature.configure(config)
 
 
 def pytest_unconfigure(config):
     """Unconfigure all subplugins."""
     cucumber_json.unconfigure(config)
+
+    previous_config = ConfigStack.get_previous()
+    Feature.unconfigure(previous_config)
 
 
 @pytest.mark.hookwrapper

--- a/pytest_bdd/plugin.py
+++ b/pytest_bdd/plugin.py
@@ -8,7 +8,7 @@ from . import generation
 from . import reporting
 from . import gherkin_terminal_reporter
 from .feature import Feature
-from .utils import ConfigStack
+from .utils import CONFIG_STACK
 
 
 def pytest_addhooks(pluginmanager):
@@ -49,7 +49,7 @@ def add_bdd_ini(parser):
 @pytest.mark.trylast
 def pytest_configure(config):
     """Configure all subplugins."""
-    ConfigStack.add(config)
+    CONFIG_STACK.append(config)
     cucumber_json.configure(config)
     gherkin_terminal_reporter.configure(config)
     Feature.configure(config)
@@ -57,9 +57,10 @@ def pytest_configure(config):
 
 def pytest_unconfigure(config):
     """Unconfigure all subplugins."""
+    CONFIG_STACK.pop()
     cucumber_json.unconfigure(config)
 
-    previous_config = ConfigStack.get_previous()
+    previous_config = CONFIG_STACK[-1] if CONFIG_STACK else None
     Feature.unconfigure(previous_config)
 
 

--- a/pytest_bdd/scenario.py
+++ b/pytest_bdd/scenario.py
@@ -38,7 +38,7 @@ from .steps import (
     recreate_function,
 )
 from .types import GIVEN
-from .utils import ConfigStack, get_args, get_fixture_value
+from .utils import CONFIG_STACK, get_args, get_fixture_value
 
 if six.PY3:  # pragma: no cover
     import runpy
@@ -246,7 +246,7 @@ def _get_scenario_decorator(feature, feature_name, scenario, scenario_name, call
                 _scenario = pytest.mark.parametrize(*param_set)(_scenario)
 
         for tag in scenario.tags.union(feature.tags):
-            config = ConfigStack.get_current()
+            config = CONFIG_STACK[-1]
             config.hook.pytest_bdd_apply_tag(tag=tag, function=_scenario)
 
         _scenario.__doc__ = "{feature_name}: {scenario_name}".format(

--- a/pytest_bdd/scenario.py
+++ b/pytest_bdd/scenario.py
@@ -273,7 +273,7 @@ def scenario(feature_name, scenario_name, encoding="utf-8", example_converters=N
 
     # Get the feature
     feature = Feature.get_feature(
-        features_base_dir, feature_name, caller_module, encoding=encoding, strict_gherkin=strict_gherkin
+        feature_name, features_base_dir, caller_module, strict_gherkin=strict_gherkin, encoding=encoding
     )
 
     # Get the sc_enario
@@ -352,7 +352,7 @@ def scenarios(*feature_paths, **kwargs):
         for name, attr in module.__dict__.items() if hasattr(attr, '__scenario__'))
 
     index = 10
-    for feature in get_features(abs_feature_paths, module, strict_gherkin=strict_gherkin):
+    for feature in get_features(abs_feature_paths, caller_module=module, strict_gherkin=strict_gherkin):
         for scenario_name, scenario_object in feature.scenarios.items():
             # skip already bound scenarios
             if (scenario_object.feature.filename, scenario_name) not in module_scenarios:

--- a/pytest_bdd/scenario.py
+++ b/pytest_bdd/scenario.py
@@ -246,7 +246,7 @@ def _get_scenario_decorator(feature, feature_name, scenario, scenario_name, call
                 _scenario = pytest.mark.parametrize(*param_set)(_scenario)
 
         for tag in scenario.tags.union(feature.tags):
-            ConfigStack.get_pytest_bdd_apply_tag_hook()(tag=tag, function=_scenario)
+            ConfigStack.pytest_bdd_apply_tag_hook(tag=tag, function=_scenario)
 
         _scenario.__doc__ = "{feature_name}: {scenario_name}".format(
             feature_name=feature_name, scenario_name=scenario_name)

--- a/pytest_bdd/scenario.py
+++ b/pytest_bdd/scenario.py
@@ -246,7 +246,8 @@ def _get_scenario_decorator(feature, feature_name, scenario, scenario_name, call
                 _scenario = pytest.mark.parametrize(*param_set)(_scenario)
 
         for tag in scenario.tags.union(feature.tags):
-            ConfigStack.pytest_bdd_apply_tag_hook(tag=tag, function=_scenario)
+            config = ConfigStack.get_current()
+            config.hook.pytest_bdd_apply_tag(tag=tag, function=_scenario)
 
         _scenario.__doc__ = "{feature_name}: {scenario_name}".format(
             feature_name=feature_name, scenario_name=scenario_name)

--- a/pytest_bdd/utils.py
+++ b/pytest_bdd/utils.py
@@ -110,3 +110,22 @@ def get_markers_args_using_iter_markers(node, mark_name):
 def get_markers_args_using_get_marker(node, mark_name):
     """Deprecated on pytest>=3.6"""
     return getattr(node.get_marker(mark_name), 'args', ())
+
+
+class ConfigStack(object):
+
+    _stack = []
+
+    @classmethod
+    def add(cls, config):
+        cls._stack.append(config)
+
+    @classmethod
+    def get_previous(cls):
+        cls._stack.pop()
+        if cls._stack:
+            return cls._stack[-1]
+
+    @classmethod
+    def get_pytest_bdd_apply_tag_hook(cls):
+        return cls._stack[-1].hook.pytest_bdd_apply_tag

--- a/pytest_bdd/utils.py
+++ b/pytest_bdd/utils.py
@@ -2,6 +2,8 @@
 
 import inspect
 
+CONFIG_STACK = []
+
 
 def get_args(func):
     """Get a list of argument names for a function.
@@ -110,23 +112,3 @@ def get_markers_args_using_iter_markers(node, mark_name):
 def get_markers_args_using_get_marker(node, mark_name):
     """Deprecated on pytest>=3.6"""
     return getattr(node.get_marker(mark_name), 'args', ())
-
-
-class ConfigStack(object):
-
-    _stack = []
-
-    @classmethod
-    def add(cls, config):
-        cls._stack.append(config)
-
-    @classmethod
-    def get_previous(cls):
-        cls._stack.pop()
-        if cls._stack:
-            return cls.get_current()
-        return None
-
-    @classmethod
-    def get_current(cls):
-        return cls._stack[-1]

--- a/pytest_bdd/utils.py
+++ b/pytest_bdd/utils.py
@@ -124,9 +124,9 @@ class ConfigStack(object):
     def get_previous(cls):
         cls._stack.pop()
         if cls._stack:
-            return cls._stack[-1]
+            return cls.get_current()
         return None
 
     @classmethod
-    def pytest_bdd_apply_tag_hook(cls, *args, **kwargs):
-        return cls._stack[-1].hook.pytest_bdd_apply_tag(*args, **kwargs)
+    def get_current(cls):
+        return cls._stack[-1]

--- a/pytest_bdd/utils.py
+++ b/pytest_bdd/utils.py
@@ -125,7 +125,8 @@ class ConfigStack(object):
         cls._stack.pop()
         if cls._stack:
             return cls._stack[-1]
+        return None
 
     @classmethod
-    def get_pytest_bdd_apply_tag_hook(cls):
-        return cls._stack[-1].hook.pytest_bdd_apply_tag
+    def pytest_bdd_apply_tag_hook(cls, *args, **kwargs):
+        return cls._stack[-1].hook.pytest_bdd_apply_tag(*args, **kwargs)


### PR DESCRIPTION
To be able to unconfigure Feature class during test execution we need to access previous config. I added `ConfigStack` for that.

I used that stack also to avoid accessing deprecated `pytest.config` while getting `config.hook.pytest_bdd_apply_tag`.

I also think that `def scenarios(*feature_paths, **kwargs):` needs refactor.