### PR TITLE
In tests use -m instead of -k for running tests by marker expressions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -741,7 +741,7 @@ scenario test, so we can use standard test selection:
 
 .. code-block:: bash
 
-    py.test -k "backend and login and successful"
+    py.test -m "backend and login and successful"
 
 The feature and scenario markers are not different from standard pytest markers, and the `@` symbol is stripped out
 automatically to allow test selector expressions. If you want to have bdd-related tags to be distinguishable from the

--- a/tests/feature/test_tags.py
+++ b/tests/feature/test_tags.py
@@ -15,13 +15,6 @@ def test_tags(request):
 
     assert test.__scenario__.tags == set(['scenario_tag_1', 'scenario_tag_2'])
     assert test.__scenario__.feature.tags == set(['feature_tag_1', 'feature_tag_2'])
-
-    assert getattr(test, 'scenario_tag_1')
-    assert getattr(test, 'scenario_tag_2')
-
-    assert getattr(test, 'feature_tag_1')
-    assert getattr(test, 'feature_tag_2')
-
     test(request)
 
 
@@ -50,18 +43,18 @@ def test_tags_selector(testdir):
 
         scenarios('test.feature')
     """)
-    result = testdir.runpytest('-k', 'scenario_tag_10 and not scenario_tag_01', '-vv').parseoutcomes()
+    result = testdir.runpytest('-m', 'scenario_tag_10 and not scenario_tag_01', '-vv').parseoutcomes()
     assert result['passed'] == 1
     assert result['deselected'] == 1
 
-    result = testdir.runpytest('-k', 'scenario_tag_01 and not scenario_tag_10', '-vv').parseoutcomes()
+    result = testdir.runpytest('-m', 'scenario_tag_01 and not scenario_tag_10', '-vv').parseoutcomes()
     assert result['passed'] == 1
     assert result['deselected'] == 1
 
-    result = testdir.runpytest('-k', 'feature_tag_1', '-vv').parseoutcomes()
+    result = testdir.runpytest('-m', 'feature_tag_1', '-vv').parseoutcomes()
     assert result['passed'] == 2
 
-    result = testdir.runpytest('-k', 'feature_tag_10', '-vv').parseoutcomes()
+    result = testdir.runpytest('-m', 'feature_tag_10', '-vv').parseoutcomes()
     assert result['deselected'] == 2
 
 


### PR DESCRIPTION
In tests we use `-k` for running tests by markers (tags). That approach works for `pytest<4.1.0`. Pytest documentation says nothing about ability to use `-k` for selecting markers.
https://docs.pytest.org/en/latest/usage.html#specifying-tests-selecting-tests

Correct approach is to use `-m` for markers.

Latest `pytest==4.1.0` removes some legacy code related to markers. My guess is that it also removed ability to use `-k` for selecting markers:
(removal of `store_legacy_markinfo` function)
https://github.com/pytest-dev/pytest/commit/9f9f6ee48beba8bbf0911e458590aa67b45bd867#diff-b1e6724759432cb1b166981e45a4a25cL238


Please note that some tests are failing because of the warnings that break regex checks of tests results. Those warnings are fixed in https://github.com/pytest-dev/pytest-bdd/pull/282

This and mentioned above pull request together make our tests green again.