### PR TITLE
Fixes #276: Add config stack

### DIFF
--- a/pytest_bdd/gherkin_terminal_reporter.py
+++ b/pytest_bdd/gherkin_terminal_reporter.py
@@ -58,7 +58,7 @@ class GherkinTerminalReporter(TerminalReporter):
 
     def pytest_runtest_logreport(self, report):
         rep = report
-        res = self.config.hook.pytest_report_teststatus(report=rep)
+        res = self.config.hook.pytest_report_teststatus(report=rep, config=self.config)
         cat, letter, word = res
 
         if not letter and not word:

--- a/pytest_bdd/plugin.py
+++ b/pytest_bdd/plugin.py
@@ -7,6 +7,7 @@ from . import cucumber_json
 from . import generation
 from . import reporting
 from . import gherkin_terminal_reporter
+from .utils import CONFIG_STACK
 
 
 def pytest_addhooks(pluginmanager):
@@ -47,12 +48,14 @@ def add_bdd_ini(parser):
 @pytest.mark.trylast
 def pytest_configure(config):
     """Configure all subplugins."""
+    CONFIG_STACK.append(config)
     cucumber_json.configure(config)
     gherkin_terminal_reporter.configure(config)
 
 
 def pytest_unconfigure(config):
     """Unconfigure all subplugins."""
+    CONFIG_STACK.pop()
     cucumber_json.unconfigure(config)
 
 

--- a/pytest_bdd/scenario.py
+++ b/pytest_bdd/scenario.py
@@ -38,7 +38,7 @@ from .steps import (
     recreate_function,
 )
 from .types import GIVEN
-from .utils import get_args, get_fixture_value
+from .utils import CONFIG_STACK, get_args, get_fixture_value
 
 if six.PY3:  # pragma: no cover
     import runpy
@@ -246,7 +246,8 @@ def _get_scenario_decorator(feature, feature_name, scenario, scenario_name, call
                 _scenario = pytest.mark.parametrize(*param_set)(_scenario)
 
         for tag in scenario.tags.union(feature.tags):
-            pytest.config.hook.pytest_bdd_apply_tag(tag=tag, function=_scenario)
+            config = CONFIG_STACK[-1]
+            config.hook.pytest_bdd_apply_tag(tag=tag, function=_scenario)
 
         _scenario.__doc__ = "{feature_name}: {scenario_name}".format(
             feature_name=feature_name, scenario_name=scenario_name)
@@ -316,12 +317,14 @@ def get_from_ini(key, default):
 
     Use if the default value is dynamic. Otherwise set default on addini call.
     """
-    value = pytest.config.getini(key)
+    config = CONFIG_STACK[-1]
+    value = config.getini(key)
     return value if value != '' else default
 
 
 def get_strict_gherkin():
-    return pytest.config.getini('bdd_strict_gherkin')
+    config = CONFIG_STACK[-1]
+    return config.getini('bdd_strict_gherkin')
 
 
 def make_python_name(string):

--- a/pytest_bdd/utils.py
+++ b/pytest_bdd/utils.py
@@ -2,6 +2,8 @@
 
 import inspect
 
+CONFIG_STACK = []
+
 
 def get_args(func):
     """Get a list of argument names for a function.

--- a/tests/feature/test_tags.py
+++ b/tests/feature/test_tags.py
@@ -127,7 +127,7 @@ def test_apply_tag_hook(testdir):
         scenarios('test.feature')
     """)
     result = testdir.runpytest('-rsx')
-    result.stdout.fnmatch_lines(["SKIP *: Not implemented yet"])
+    result.stdout.fnmatch_lines(["SKIP*: Not implemented yet"])
     result.stdout.fnmatch_lines(["*= 1 skipped, 1 xpassed * =*"])
 
 


### PR DESCRIPTION
Simplified solution for failing tests.

Prepared based on comments from https://github.com/pytest-dev/pytest-bdd/pull/282

I also added two small fixes for `pytest==4.2.0`