### PR TITLE
Drop ancient pytest compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,6 @@ matrix:
   include:
     - python: "2.7"
       env: TOXENV=py27-pytestlatest-linters
-    - env: TOXENV=py27-pytest30
-    - env: TOXENV=py27-pytest31
-    - env: TOXENV=py27-pytest32
     - env: TOXENV=py27-pytest33
     - env: TOXENV=py27-pytest34
     - env: TOXENV=py27-pytest35

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+Unreleased
+----------
+
+- Drop support for pytest < 3.0
+
 3.0.2
 ------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 Unreleased
 ----------
 
-- Drop support for pytest < 3.0
+- Drop support for pytest < 3.3
 
 3.0.2
 ------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 Unreleased
 ----------
 
-- Drop support for pytest < 3.3
+- Drop support for pytest < 3.3.2
 
 3.0.2
 ------

--- a/pytest_bdd/scenario.py
+++ b/pytest_bdd/scenario.py
@@ -38,7 +38,7 @@ from .steps import (
     recreate_function,
 )
 from .types import GIVEN
-from .utils import CONFIG_STACK, get_args, get_fixture_value
+from .utils import CONFIG_STACK, get_args
 
 if six.PY3:  # pragma: no cover
     import runpy
@@ -70,7 +70,7 @@ def find_argumented_step_fixture_name(name, type_, fixturemanager, request=None)
                 parser_name = get_step_fixture_name(parser.name, type_)
                 if request:
                     try:
-                        get_fixture_value(request, parser_name)
+                        request.getfixturevalue(parser_name)
                     except pytest_fixtures.FixtureLookupError:
                         continue
                 return parser_name
@@ -88,12 +88,12 @@ def _find_step_function(request, step, scenario, encoding):
     """
     name = step.name
     try:
-        return get_fixture_value(request, get_step_fixture_name(name, step.type, encoding))
+        return request.getfixturevalue(get_step_fixture_name(name, step.type, encoding))
     except pytest_fixtures.FixtureLookupError:
         try:
             name = find_argumented_step_fixture_name(name, step.type, request._fixturemanager, request)
             if name:
-                return get_fixture_value(request, name)
+                return request.getfixturevalue(name)
             raise
         except pytest_fixtures.FixtureLookupError:
             raise exceptions.StepDefinitionNotFoundError(
@@ -128,7 +128,7 @@ def _execute_step_function(request, scenario, step, step_func):
     kw["step_func_args"] = {}
     try:
         # Get the step argument values.
-        kwargs = dict((arg, get_fixture_value(request, arg)) for arg in get_args(step_func))
+        kwargs = dict((arg, request.getfixturevalue(arg)) for arg in get_args(step_func))
         kw["step_func_args"] = kwargs
 
         request.config.hook.pytest_bdd_before_step_call(**kw)

--- a/pytest_bdd/steps.py
+++ b/pytest_bdd/steps.py
@@ -49,7 +49,7 @@ from .exceptions import (
     StepError,
 )
 from .parsers import get_parser
-from .utils import get_args, get_request_fixture_defs, get_request_fixture_names
+from .utils import get_args, get_request_fixture_names
 
 
 def get_step_fixture_name(name, type_, encoding=None):
@@ -304,12 +304,12 @@ def inject_fixture(request, arg, value):
     fd = pytest_fixtures.FixtureDef(**fd_kwargs)
     fd.cached_result = (value, 0, None)
 
-    old_fd = get_request_fixture_defs(request).get(arg)
+    old_fd = request._fixture_defs.get(arg)
     add_fixturename = arg not in request.fixturenames
 
     def fin():
         request._fixturemanager._arg2fixturedefs[arg].remove(fd)
-        get_request_fixture_defs(request)[arg] = old_fd
+        request._fixture_defs[arg] = old_fd
 
         if add_fixturename:
             get_request_fixture_names(request).remove(arg)
@@ -319,6 +319,6 @@ def inject_fixture(request, arg, value):
     # inject fixture definition
     request._fixturemanager._arg2fixturedefs.setdefault(arg, []).insert(0, fd)
     # inject fixture value in request cache
-    get_request_fixture_defs(request)[arg] = fd
+    request._fixture_defs[arg] = fd
     if add_fixturename:
         get_request_fixture_names(request).append(arg)

--- a/pytest_bdd/steps.py
+++ b/pytest_bdd/steps.py
@@ -49,8 +49,7 @@ from .exceptions import (
     StepError,
 )
 from .parsers import get_parser
-from .utils import get_args, get_fixture_value_raw, set_fixture_value, get_request_fixture_defs, \
-    get_request_fixture_names
+from .utils import get_args, get_request_fixture_defs, get_request_fixture_names
 
 
 def get_step_fixture_name(name, type_, encoding=None):
@@ -308,8 +307,6 @@ def inject_fixture(request, arg, value):
     old_fd = get_request_fixture_defs(request).get(arg)
     add_fixturename = arg not in request.fixturenames
 
-    old_value = get_fixture_value_raw(request, arg)  # Compatibility with pytest < 3.3.2
-
     def fin():
         request._fixturemanager._arg2fixturedefs[arg].remove(fd)
         get_request_fixture_defs(request)[arg] = old_fd
@@ -317,14 +314,11 @@ def inject_fixture(request, arg, value):
         if add_fixturename:
             get_request_fixture_names(request).remove(arg)
 
-        set_fixture_value(request, arg, old_value)  # Compatibility with pytest < 3.3.2
-
     request.addfinalizer(fin)
 
     # inject fixture definition
     request._fixturemanager._arg2fixturedefs.setdefault(arg, []).insert(0, fd)
     # inject fixture value in request cache
     get_request_fixture_defs(request)[arg] = fd
-    set_fixture_value(request, arg, value)
     if add_fixturename:
         get_request_fixture_names(request).append(arg)

--- a/pytest_bdd/steps.py
+++ b/pytest_bdd/steps.py
@@ -49,7 +49,7 @@ from .exceptions import (
     StepError,
 )
 from .parsers import get_parser
-from .utils import get_args, get_fixture_value, get_fixture_value_raw, set_fixture_value, get_request_fixture_defs, \
+from .utils import get_args, get_fixture_value_raw, set_fixture_value, get_request_fixture_defs, \
     get_request_fixture_names
 
 
@@ -82,7 +82,7 @@ def given(name, fixture=None, converters=None, scope='function', target_fixture=
         module = get_caller_module()
 
         def step_func(request):
-            return get_fixture_value(request, fixture)
+            return request.getfixturevalue(fixture)
 
         step_func.step_type = GIVEN
         step_func.converters = converters
@@ -162,7 +162,7 @@ def _step_decorator(step_type, step_name, converters=None, scope='function', tar
                 func = pytest.fixture(scope=scope)(func)
 
             def step_func(request):
-                result = get_fixture_value(request, func.__name__)
+                result = request.getfixturevalue(func.__name__)
                 if target_fixture:
                     inject_fixture(request, target_fixture, result)
                 return result

--- a/pytest_bdd/steps.py
+++ b/pytest_bdd/steps.py
@@ -49,7 +49,7 @@ from .exceptions import (
     StepError,
 )
 from .parsers import get_parser
-from .utils import get_args, get_request_fixture_names
+from .utils import get_args
 
 
 def get_step_fixture_name(name, type_, encoding=None):
@@ -312,7 +312,7 @@ def inject_fixture(request, arg, value):
         request._fixture_defs[arg] = old_fd
 
         if add_fixturename:
-            get_request_fixture_names(request).remove(arg)
+            request._pyfuncitem._fixtureinfo.names_closure.remove(arg)
 
     request.addfinalizer(fin)
 
@@ -321,4 +321,4 @@ def inject_fixture(request, arg, value):
     # inject fixture value in request cache
     request._fixture_defs[arg] = fd
     if add_fixturename:
-        get_request_fixture_names(request).append(arg)
+        request._pyfuncitem._fixtureinfo.names_closure.append(arg)

--- a/pytest_bdd/utils.py
+++ b/pytest_bdd/utils.py
@@ -25,19 +25,6 @@ def get_args(func):
         return inspect.getargspec(func).args
 
 
-def get_fixture_value(request, name):
-    """Get the given fixture from the pytest request object.
-
-    getfuncargvalue() is deprecated in pytest 3.0, so we need to use
-    getfixturevalue() there.
-    """
-    try:
-        getfixturevalue = request.getfixturevalue
-    except AttributeError:
-        getfixturevalue = request.getfuncargvalue
-    return getfixturevalue(name)
-
-
 def get_fixture_value_raw(request, name):
     """Set the given raw fixture value from the pytest request object.
 

--- a/pytest_bdd/utils.py
+++ b/pytest_bdd/utils.py
@@ -25,17 +25,6 @@ def get_args(func):
         return inspect.getargspec(func).args
 
 
-def get_request_fixture_names(request):
-    """Get list of fixture names for the given FixtureRequest.
-
-    Get the internal and mutable list of fixture names in the enclosing scope of
-    the given request object.
-
-    Compatibility with pytest 3.0.
-    """
-    return request._pyfuncitem._fixtureinfo.names_closure
-
-
 def get_parametrize_markers_args(node):
     """In pytest 3.6 new API to access markers has been introduced and it deprecated
     MarkInfo objects.

--- a/pytest_bdd/utils.py
+++ b/pytest_bdd/utils.py
@@ -25,17 +25,6 @@ def get_args(func):
         return inspect.getargspec(func).args
 
 
-def get_request_fixture_defs(request):
-    """Get the internal list of FixtureDefs cached into the given request object.
-
-    Compatibility with pytest 3.0.
-    """
-    try:
-        return request._fixture_defs
-    except AttributeError:
-        return getattr(request, "_fixturedefs", {})
-
-
 def get_request_fixture_names(request):
     """Get list of fixture names for the given FixtureRequest.
 

--- a/pytest_bdd/utils.py
+++ b/pytest_bdd/utils.py
@@ -25,34 +25,6 @@ def get_args(func):
         return inspect.getargspec(func).args
 
 
-def get_fixture_value_raw(request, name):
-    """Set the given raw fixture value from the pytest request object.
-
-    :note: Compatibility with pytest < 3.3.2
-    """
-    try:
-        return request._fixture_values.get(name)
-    except AttributeError:
-        try:
-            return request._funcargs.get(name)
-        except AttributeError:
-            pass
-
-
-def set_fixture_value(request, name, value):
-    """Set the given fixture value on the pytest request object.
-
-    :note: Compatibility with pytest < 3.3.2
-    """
-    try:
-        request._fixture_values[name] = value
-    except AttributeError:
-        try:
-            request._funcargs[name] = value
-        except AttributeError:
-            pass
-
-
 def get_request_fixture_defs(request):
     """Get the internal list of FixtureDefs cached into the given request object.
 

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ setup(
         "parse",
         "parse_type",
         "py",
-        "pytest>=2.9.0",
+        "pytest>=3.0.0",
         "six>=1.9.0",
     ],
     # the following makes a plugin available to py.test

--- a/tests/feature/test_multiline.py
+++ b/tests/feature/test_multiline.py
@@ -10,7 +10,6 @@ from pytest_bdd import (
     scenario,
     then,
 )
-from pytest_bdd.utils import get_fixture_value
 
 
 @pytest.mark.parametrize(["feature_text", "expected_text"], [
@@ -73,7 +72,7 @@ def test_multiline(request, tmpdir, feature_text, expected_text):
 
     @scenario(file_name.strpath, 'Multiline step using sub indentation')
     def test_multiline(request):
-        assert get_fixture_value(request, 'i_have_text') == expected_text
+        assert request.getfixturevalue('i_have_text') == expected_text
     test_multiline(request)
 
 

--- a/tests/library/child/test_local_override.py
+++ b/tests/library/child/test_local_override.py
@@ -5,7 +5,6 @@ Check the parent given steps are collected, override them locally.
 
 from pytest_bdd import given
 from pytest_bdd.steps import get_step_fixture_name, GIVEN
-from pytest_bdd.utils import get_fixture_value
 
 
 @given('I have locally overriden fixture')
@@ -22,11 +21,11 @@ def test_override(request, overridable):
     """Test locally overriden fixture."""
 
     # Test the fixture is also collected by the text name
-    fixture = get_fixture_value(request, get_step_fixture_name('I have locally overriden fixture', GIVEN))
+    fixture = request.getfixturevalue(get_step_fixture_name('I have locally overriden fixture', GIVEN))
     assert fixture(request) == 'local'
 
     # 'I have the overriden fixture' stands for overridable and is overriden locally
-    fixture = get_fixture_value(request, get_step_fixture_name('I have the overriden fixture', GIVEN))
+    fixture = request.getfixturevalue(get_step_fixture_name('I have the overriden fixture', GIVEN))
     assert fixture(request) == 'local'
 
     assert overridable == 'local'

--- a/tests/library/test_parent.py
+++ b/tests/library/test_parent.py
@@ -3,7 +3,6 @@
 Check the parent givens are collected and overriden in the local conftest.
 """
 from pytest_bdd.steps import get_step_fixture_name, WHEN
-from pytest_bdd.utils import get_fixture_value
 
 
 def test_parent(parent, overridable):
@@ -17,4 +16,4 @@ def test_parent(parent, overridable):
 
 def test_global_when_step(request):
     """Test when step defined in the parent conftest."""
-    get_fixture_value(request, get_step_fixture_name('I use a when step from the parent conftest', WHEN))
+    request.getfixturevalue(get_step_fixture_name('I use a when step from the parent conftest', WHEN))

--- a/tests/steps/test_steps.py
+++ b/tests/steps/test_steps.py
@@ -3,7 +3,6 @@
 import pytest
 from pytest_bdd import given, when, then
 from pytest_bdd.steps import get_step_fixture_name, WHEN, THEN
-from pytest_bdd.utils import get_fixture_value
 
 
 @when('I do stuff')
@@ -22,10 +21,10 @@ def test_when_then(request):
     This test checks that when and then are not evaluated
     during fixture collection that might break the scenario.
     """
-    do_stuff_ = get_fixture_value(request, get_step_fixture_name('I do stuff', WHEN))
+    do_stuff_ = request.getfixturevalue(get_step_fixture_name('I do stuff', WHEN))
     assert callable(do_stuff_)
 
-    check_stuff_ = get_fixture_value(request, get_step_fixture_name('I check stuff', THEN))
+    check_stuff_ = request.getfixturevalue(get_step_fixture_name('I check stuff', THEN))
     assert callable(check_stuff_)
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 distshare={homedir}/.tox/distshare
-envlist=py27-pytestlatest-linters,py27-pytest{29,30,31,32,33,34,35,36,37,38,39,310,40,41,42,latest},py{34,35,36,37}-pytestlatest,py27-pytestlatest-xdist
+envlist=py27-pytestlatest-linters,py27-pytest{30,31,32,33,34,35,36,37,38,39,310,40,41,42,latest},py{34,35,36,37}-pytestlatest,py27-pytestlatest-xdist
 skip_missing_interpreters = true
 
 [testenv]
@@ -20,7 +20,6 @@ deps =
     pytest32: pytest~=3.2.0
     pytest31: pytest~=3.1.0
     pytest30: pytest~=3.0.0
-    pytest29: pytest~=2.9.0
     pytest30,pytest29: pytest-warnings
     -r{toxinidir}/requirements-testing.txt
 commands = py.test tests --junitxml={envlogdir}/junit-{envname}.xml

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 distshare={homedir}/.tox/distshare
-envlist=py27-pytestlatest-linters,py27-pytest{30,31,32,33,34,35,36,37,38,39,310,40,41,42,latest},py{34,35,36,37}-pytestlatest,py27-pytestlatest-xdist
+envlist=py27-pytestlatest-linters,py27-pytest{33,34,35,36,37,38,39,310,40,41,42,latest},py{34,35,36,37}-pytestlatest,py27-pytestlatest-xdist
 skip_missing_interpreters = true
 
 [testenv]
@@ -16,11 +16,7 @@ deps =
     pytest36: pytest~=3.6.0
     pytest35: pytest~=3.5.0
     pytest34: pytest~=3.4.0
-    pytest33: pytest~=3.3.0
-    pytest32: pytest~=3.2.0
-    pytest31: pytest~=3.1.0
-    pytest30: pytest~=3.0.0
-    pytest30,pytest29: pytest-warnings
+    pytest33: pytest~=3.3.2
     -r{toxinidir}/requirements-testing.txt
 commands = py.test tests --junitxml={envlogdir}/junit-{envname}.xml
 


### PR DESCRIPTION
Removed compatibility with pytest < 3.3.2
The test suite still appears to work with pytest >= 3.0.0, but let's remove the declared compatibility until 3.3.2 anyway (it is more that 1 year old).