### PR TITLE
gherkin terminal reporter tests steps renamed to not being collected …

### DIFF
--- a/tests/feature/gherkin_terminal_reporter.feature
+++ b/tests/feature/gherkin_terminal_reporter.feature
@@ -2,46 +2,46 @@ Feature: Gherkin terminal reporter
 
   Scenario: Should default output be the same as regular terminal reporter
     Given there is gherkin scenario implemented
-    When tests are run
+    When I run tests
     Then output must be formatted the same way as regular one
 
   Scenario: Should verbose mode enable displaying feature and scenario names rather than test names in a single line
     Given there is gherkin scenario implemented
-    When tests are run with verbose mode
+    When I run tests with verbose mode
     Then output should contain single line feature description
     And output should contain single line scenario description
 
   Scenario: Should verbose mode preserve displaying of regular tests as usual
     Given there is non-gherkin scenario implemented
-    When tests are run with verbose mode
+    When I run tests with verbose mode
     Then output must be formatted the same way as regular one
 
   Scenario: Should double verbose mode enable displaying of full gherkin scenario description
     Given there is gherkin scenario implemented
-    When tests are run with very verbose mode
+    When I run tests with very verbose mode
     Then output must contain full gherkin scenario description
 
   Scenario: Should error message be displayed when no scenario is found
     Given there is gherkin scenario without implementation
-    When tests are run with any verbosity mode
+    When I run tests with any verbosity mode
     Then output contains error about missing scenario implementation
 
   Scenario: Should error message be displayed when no step is found
     Given there is gherkin scenario partially implemented
-    When tests are run with any verbosity mode
+    When I run tests with any verbosity mode
     Then output contains error about missing step implementation
 
   Scenario: Should error message be displayed when error occurs during test execution
     Given there is gherkin scenario with broken implementation
-    When tests are run with any verbosity mode
+    When I run tests with any verbosity mode
     Then output contains error about missing scenario implementation
 
   Scenario: Should local variables be displayed when --showlocals option is used
     Given there is gherkin scenario with broken implementation
-    When tests are run with --showlocals
+    When I run tests with --showlocals
     Then error traceback contains local variable descriptions
 
   Scenario: Should step parameters be replaced by their values
     Given there is gherkin scenario outline implemented
-    When tests are run with step expanded mode
+    When I run tests with step expanded mode
     Then output must contain parameters values

--- a/tests/feature/test_gherkin_terminal_reporter.py
+++ b/tests/feature/test_gherkin_terminal_reporter.py
@@ -152,8 +152,8 @@ def gherkin_scenario_outline(testdir):
     return example
 
 
-@when("tests are run")
-def tests_are_run(testdir, test_execution):
+@when("I run tests")
+def run_tests(testdir, test_execution):
     test_execution['regular'] = testdir.runpytest()
     test_execution['gherkin'] = testdir.runpytest('--gherkin-terminal-reporter')
 
@@ -173,20 +173,20 @@ def output_must_be_the_same_as_regular_reporter(test_execution):
         assert l1 == l2
 
 
-@when("tests are run with verbose mode")
-def tests_are_run_with_verbose_mode(testdir, test_execution):
+@when("I run tests with verbose mode")
+def run_tests_with_verbose_mode(testdir, test_execution):
     test_execution['regular'] = testdir.runpytest('-v')
     test_execution['gherkin'] = testdir.runpytest('--gherkin-terminal-reporter', '-v')
 
 
-@when("tests are run with very verbose mode")
-def tests_are_run_with_very_verbose_mode(testdir, test_execution):
+@when("I run tests with very verbose mode")
+def run_tests_with_very_verbose_mode(testdir, test_execution):
     test_execution['regular'] = testdir.runpytest('-vv')
     test_execution['gherkin'] = testdir.runpytest('--gherkin-terminal-reporter', '-vv')
 
 
-@when("tests are run with step expanded mode")
-def tests_are_run_with_step_expanded_mode(testdir, test_execution):
+@when("I run tests with step expanded mode")
+def run_tests_with_step_expanded_mode(testdir, test_execution):
     test_execution['regular'] = testdir.runpytest('-vv')
     test_execution['gherkin'] = testdir.runpytest(
         '--gherkin-terminal-reporter',
@@ -238,8 +238,8 @@ def gherkin_scenario_without_implementation(testdir):
     """)
 
 
-@when('tests are run with any verbosity mode')
-def tests_are_run_with_any_verbosity_mode(
+@when('I run tests with any verbosity mode')
+def run_tests_with_any_verbosity_mode(
         test_execution, verbosity_mode, testdir,
         gherkin_scenario_without_implementation):
     #  test_execution['gherkin'] = testdir.runpytest(
@@ -323,8 +323,8 @@ def there_is_gherkin_scenario_with_broken_implementation(testdir):
     """)
 
 
-@when('tests are run with --showlocals')
-def tests_are_run_with___showlocals(test_execution, testdir):
+@when('I run tests with --showlocals')
+def run_tests_with___showlocals(test_execution, testdir):
     test_execution['gherkin'] = testdir.runpytest('--gherkin-terminal-reporter', '--showlocals')
 
 


### PR DESCRIPTION
…as test items by pytest

Pytest runs functions as test when they start with `test*`. Due to that some our test steps are treated as tests and pytest runs them:

```
tests/feature/test_gherkin_terminal_reporter.py::tests_are_run PASSED                                         [ 26%]
tests/feature/test_gherkin_terminal_reporter.py::tests_are_run_with_verbose_mode PASSED                       [ 27%]
tests/feature/test_gherkin_terminal_reporter.py::tests_are_run_with_very_verbose_mode PASSED                  [ 28%]
tests/feature/test_gherkin_terminal_reporter.py::tests_are_run_with_step_expanded_mode PASSED                 [ 28%]
tests/feature/test_gherkin_terminal_reporter.py::tests_are_run_with_any_verbosity_mode[compact mode] PASSED   [ 29%]
tests/feature/test_gherkin_terminal_reporter.py::tests_are_run_with_any_verbosity_mode[line per test] PASSED  [ 30%]
tests/feature/test_gherkin_terminal_reporter.py::tests_are_run_with_any_verbosity_mode[verbose] PASSED        [ 30%]
tests/feature/test_gherkin_terminal_reporter.py::tests_are_run_with___showlocals PASSED                       [ 31%]
```

This PR renames those steps.
