### PR TITLE
Use normal parameter substitution with scenario outlines

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -22,5 +22,6 @@ These people have contributed to `pytest-bdd`, in alphabetical order:
 * `Leonardo Santagada <santagada@github.com>`_
 * `Milosz Sliwinski <sliwinski-milosz>`_
 * `Michiel Holtkamp <github@elfstone.nl>`_
+* `Nick Farrell <nicholas.farrell@gmail.com>`_
 * `Robin Pedersen <ropez@github.com>`_
 * `Sergey Kraynev <sergejyit@gmail.com>`_

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,29 @@
 [pytest]
 pep8maxlinelength=120
 addopts=-vvl
+markers=
+    scenario-outline-passing-tag
+    scenario-outline-failing-tag
+    scenario-passing-tag
+    scenario-failing-tag
+    scenario_tag_1
+    scenario_tag_2
+    scenario_tag_01
+    scenario_tag_02
+    scenario_tag_03
+    scenario_tag_04
+    scenario_tag_05
+    scenario_tag_06
+    scenario_tag_07
+    scenario_tag_08
+    scenario_tag_09
+    scenario_tag_10
+    scenario_tag_20
+    tag
+    pep8
+    feature-tag
+    feature_tag_1
+    feature_tag_2
 filterwarnings =
     error
     ignore::DeprecationWarning

--- a/pytest_bdd/feature.py
+++ b/pytest_bdd/feature.py
@@ -393,9 +393,9 @@ class Feature(object):
             # We are not iterating directly over 'scenarios' as
             # we may need to mutate it
             scenario = self.scenarios[scenario_name]
-            params = list(scenario.get_params())
+            params = [param for param in scenario.get_params() if param]
             processed_examples = False
-            if (not params[0]) or getattr(scenario, 'example_converters', None):
+            if (not params) or getattr(scenario, 'example_converters', None):
                 # Either this has no examples, or it has legacy example_converters.
                 # We cannot safely treat this in the normal way, and fall back on
                 # old approach.

--- a/pytest_bdd/scenario.py
+++ b/pytest_bdd/scenario.py
@@ -280,9 +280,10 @@ def scenario(feature_name, scenario_name, encoding="utf-8", example_converters=N
         strict_gherkin = get_strict_gherkin()
     feature = Feature.get_feature(features_base_dir, feature_name, encoding=encoding, strict_gherkin=strict_gherkin)
 
-    # Get the sc_enario
+    # Get the sc_enario. First look in the normal place, but fall back
+    # to looking in the 'legacy' location.
     try:
-        scenario = feature.scenarios[scenario_name]
+        scenario = feature.scenarios.get(scenario_name) or feature.legacy_scenarios[scenario_name]
     except KeyError:
         raise exceptions.ScenarioNotFound(
             u'Scenario "{scenario_name}" in feature "{feature_name}" in {feature_filename} is not found.'.format(

--- a/tests/feature/outline_modern.feature
+++ b/tests/feature/outline_modern.feature
@@ -1,0 +1,16 @@
+Feature: Outline
+
+    Examples:
+    | first | consume | remaining |
+    |  12   |  5      |  7        |
+    |  5    |  4      |  1        |
+
+    Scenario Outline: Outlined modern given, when, thens
+        Given there were <first> <foods>
+        When I ate <consume> <foods>
+        Then I should have had <remaining> <foods>
+
+        Examples:
+        | foods      |
+        | ice-creams |
+        | almonds    |

--- a/tests/feature/test_outline.py
+++ b/tests/feature/test_outline.py
@@ -1,10 +1,11 @@
 """Scenario Outline tests."""
 import re
 import textwrap
-
+from six import text_type
 import pytest
 
-from pytest_bdd import given, when, then, scenario
+from pytest_bdd import given, when, then, scenario, scenarios
+from pytest_bdd.parsers import parse
 from pytest_bdd import exceptions
 from pytest_bdd.utils import get_parametrize_markers_args
 
@@ -160,6 +161,26 @@ def should_have_left_fruits(start_fruits, start, eat, left, fruits):
     assert start_fruits[fruits]['eat'] == eat
 
 
+@given(parse('there were {start:d} {fruits}'))
+def started_fruits(start, fruits):
+    assert isinstance(start, int)
+    return {fruits: dict(start=start)}
+
+
+@when(parse('I ate {eat:g} {fruits}'))
+def ate_fruits(started_fruits, eat, fruits):
+    assert isinstance(eat, float)
+    started_fruits[fruits]['eat'] = eat
+
+
+@then(parse('I should have had {left} {fruits}'))
+def should_have_had_left_fruits(started_fruits, start, eat, left, fruits):
+    assert isinstance(left, (text_type, str))
+    assert start - eat == int(left)
+    assert started_fruits[fruits]['start'] == start
+    assert started_fruits[fruits]['eat'] == eat
+
+
 @scenario(
     'outline_feature.feature',
     'Outlined given, when, thens',
@@ -172,3 +193,5 @@ def test_outlined_feature(request):
         ['fruits'],
         [[u'oranges'], [u'apples']]
     )
+
+scenarios('outline_modern.feature')

--- a/tests/feature/test_tags.py
+++ b/tests/feature/test_tags.py
@@ -136,6 +136,10 @@ def test_tag_with_spaces(testdir):
         import pytest
 
         @pytest.hookimpl(tryfirst=True)
+        def pytest_configure(config):
+            config.addinivalue_line("markers", "test with spaces")
+
+        @pytest.hookimpl(tryfirst=True)
         def pytest_bdd_apply_tag(tag, function):
             assert tag == 'test with spaces'
     """)


### PR DESCRIPTION
Currently, scenario outlines use an alternate parser to the scenarios, resulting in needing to decorate step functions multiples times, and requiring gherkin authors to use identical parameters in scenario outlines to those used in the step definitions.

This patch will attempt to 'promote' examples to being fully-fledged scenarios, which the normal parsers can then map to individual step functions.

If example_converters have been defined (which was introduced as a hack to work around the fact the normal parsers were not compatible with scenario outlines), the legacy behaviour is maintained.