### PR TITLE
Add gettext support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,9 @@ python:
   - "3.6"
   - "3.7"
 
-install: pip install tox tox-travis
+install:
+  - make translate
+  - pip install tox tox-travis
 
 script: tox --recreate
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,4 @@ include *.rst
 include *.txt
 include setup.py
 include pytest_bdd/templates/*.mak
+include pytest_bdd/locales/*/LC_MESSAGES/*.mo

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,13 @@ PATH := .env/bin:$(PATH)
 develop: .env
 	pip install -e . -r requirements-testing.txt tox python-coveralls
 
-coverage: develop
+translate:
+	msgfmt pytest_bdd/locales/en/LC_MESSAGES/step-prefixes.po \
+		-o pytest_bdd/locales/en/LC_MESSAGES/step-prefixes.mo
+	msgfmt pytest_bdd/locales/pt_BR/LC_MESSAGES/step-prefixes.po \
+		-o pytest_bdd/locales/pt_BR/LC_MESSAGES/step-prefixes.mo
+
+coverage: develop translate
 	coverage run --source=pytest_bdd .env/bin/py.test tests
 	coverage report -m
 

--- a/pytest_bdd/locales/en/LC_MESSAGES/step-prefixes.po
+++ b/pytest_bdd/locales/en/LC_MESSAGES/step-prefixes.po
@@ -1,0 +1,45 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: pytest_bdd 3.2.0\n"
+"POT-Creation-Date: 2019-06-27 14:54+-03\n"
+"PO-Revision-Date: 2019-06-27 15:00-0300\n"
+"Last-Translator: <diogodutramata@gmail.com>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: pygettext.py 1.5\n"
+"Language: en\n"
+
+msgid "Feature: "
+msgstr ""
+
+msgid "Scenario Outline: "
+msgstr ""
+
+msgid "Examples: Vertical"
+msgstr ""
+
+msgid "Examples:"
+msgstr ""
+
+msgid "Scenario: "
+msgstr ""
+
+msgid "Background:"
+msgstr ""
+
+msgid "Given "
+msgstr ""
+
+msgid "When "
+msgstr ""
+
+msgid "Then "
+msgstr ""
+
+msgid "And "
+msgstr ""
+
+msgid "But "
+msgstr ""

--- a/pytest_bdd/locales/pt_BR/LC_MESSAGES/step-prefixes.po
+++ b/pytest_bdd/locales/pt_BR/LC_MESSAGES/step-prefixes.po
@@ -1,0 +1,45 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: pytest_bdd 3.2.0\n"
+"POT-Creation-Date: 2019-06-27 14:54+-03\n"
+"PO-Revision-Date: 2019-06-27 15:00-0300\n"
+"Last-Translator: <diogodutramata@gmail.com>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: pygettext.py 1.5\n"
+"Language: pt_BR\n"
+
+msgid "Feature: "
+msgstr "Funcionalidade: "
+
+msgid "Scenario Outline: "
+msgstr "Esquema do Cenário: "
+
+msgid "Examples: Vertical"
+msgstr "Exemplos: Vertical"
+
+msgid "Examples:"
+msgstr "Exemplos:"
+
+msgid "Scenario: "
+msgstr "Cenário: "
+
+msgid "Background:"
+msgstr "Descrição:"
+
+msgid "Given "
+msgstr "Dado "
+
+msgid "When "
+msgstr "Quando "
+
+msgid "Then "
+msgstr "Então "
+
+msgid "And "
+msgstr "E "
+
+msgid "But "
+msgstr "Mas "


### PR DESCRIPTION
First translation was written for portuguese, according to https://cucumber.io/docs/gherkin/reference/#spoken-languages.

The PR also enables the language reset during runtime.