### PR TITLE
 Allow unicode type in given step names in Py 2 

### DIFF
--- a/pytest_bdd/steps.py
+++ b/pytest_bdd/steps.py
@@ -85,7 +85,7 @@ def given(name, fixture=None, converters=None, scope='function', target_fixture=
 
         step_func.step_type = GIVEN
         step_func.converters = converters
-        step_func.__name__ = name
+        step_func.__name__ = force_encode(name, 'ascii')
         step_func.fixture = fixture
         func = pytest.fixture(scope=scope)(lambda: step_func)
         func.__doc__ = 'Alias for the "{0}" fixture.'.format(fixture)

--- a/tests/steps/test_unicode.py
+++ b/tests/steps/test_unicode.py
@@ -33,6 +33,9 @@ def string():
     return {'content': ''}
 
 
+given(u"I have an alias with a unicode type for foo", fixture="foo")
+
+
 @given(parsers.parse(u"у мене є рядок який містить '{content}'"))
 def there_is_a_string_with_content(content, string):
     """Create string with unicode content."""

--- a/tests/steps/unicode.feature
+++ b/tests/steps/unicode.feature
@@ -7,3 +7,7 @@ Feature: Юнікодні символи
     Scenario: Steps in .py file have unicode
         Given there is an other string with content 'якийсь контент'
         Then I should see that the other string equals to content 'якийсь контент'
+
+    Scenario: Given names have unicode types
+        Given I have an alias with a unicode type for foo
+        Then foo should be "foo"


### PR DESCRIPTION
This is useful when migrating from Py 2 to Py 3 when using `from __future__ import unicode_literals` in your step definition files because all given steps can remain untouched.

To pytest_bdd it does not matter whether the step name is a `str` or `unicode` in Py 2, as long as the name does not contain non-ascii characters. (because it is used to set the function `__name__` which only allows ascii in Py 2)

Py 3 is not affected by these changes.