### PR TITLE
Fix pytest --generate --fixtures flag

### DIFF
--- a/pytest_bdd/plugin.py
+++ b/pytest_bdd/plugin.py
@@ -81,7 +81,7 @@ def pytest_bdd_after_step(request, feature, scenario, step, step_func, step_func
 
 
 def pytest_cmdline_main(config):
-    generation.cmdline_main(config)
+    return generation.cmdline_main(config)
 
 
 def pytest_bdd_apply_tag(tag, function):

--- a/tests/generation/test_generate_missing.py
+++ b/tests/generation/test_generate_missing.py
@@ -56,3 +56,6 @@ def test_generate_missing(testdir):
     )
 
     result.stdout.fnmatch_lines(["Please place the code above to the test file(s):"])
+
+    assert not result.stderr.str()
+    assert result.ret == 0


### PR DESCRIPTION
This patch resolves the issues where pytest will try to double load the
pytest_cmd_main.

This resolves issue #204