### PR TITLE
Feature/issue 234 add scenario attach method

### DIFF
--- a/pytest_bdd/cucumber_json.py
+++ b/pytest_bdd/cucumber_json.py
@@ -143,6 +143,7 @@ class LogBDDCucumberJSON(object):
                 "keyword": step["keyword"],
                 "name": step_name,
                 "line": step["line_number"],
+                "embeddings": step['embeddings'],
                 "match": {"location": ""},
                 "result": self._get_result(step, report, error_message),
             }

--- a/pytest_bdd/cucumber_json.py
+++ b/pytest_bdd/cucumber_json.py
@@ -143,7 +143,7 @@ class LogBDDCucumberJSON(object):
                 "keyword": step["keyword"],
                 "name": step_name,
                 "line": step["line_number"],
-                "embeddings": step['embeddings'],
+                "embeddings": step["embeddings"],
                 "match": {"location": ""},
                 "result": self._get_result(step, report, error_message),
             }

--- a/pytest_bdd/feature.py
+++ b/pytest_bdd/feature.py
@@ -454,6 +454,14 @@ class Scenario(object):
         step.scenario = self
         self._steps.append(step)
 
+    def attach(self, data, media_type="text/plain"):
+        """Add attachment to step, such as text, images.
+
+        :param data: actual data of Attachment, can be plain text or base64 encoded
+        :param media_type: actual media type of Attachment, such as text/plain, image/png
+        """
+        self.steps[-1].attach(data, media_type)
+
     @property
     def steps(self):
         """Get scenario steps including background steps.
@@ -521,6 +529,7 @@ class Step(object):
         self.type = type
         self.line_number = line_number
         self.failed = False
+        self.embeddings = []
         self.start = 0
         self.stop = 0
         self.scenario = None
@@ -532,6 +541,22 @@ class Step(object):
         :param str line: Line of text - the continuation of the step name.
         """
         self.lines.append(line)
+
+    def attach(self, data, media_type="text/plain"):
+        """Add attachment to step, such as text, images.
+
+        :param data: actual data of Attachment, can be plain text or base64 encoded
+        :param media_type: actual media type of Attachment, such as text/plain, image/png
+        """
+
+        json_attachment = \
+            {
+                "data": data,
+                "media": {
+                    "type": media_type
+                }
+            }
+        self.embeddings.append(json_attachment)
 
     @property
     def name(self):

--- a/pytest_bdd/feature.py
+++ b/pytest_bdd/feature.py
@@ -548,9 +548,7 @@ class Step(object):
         :param data: actual data of Attachment, can be plain text or base64 encoded
         :param media_type: actual media type of Attachment, such as text/plain, image/png
         """
-
-        json_attachment = \
-            {
+        json_attachment = {
                 "data": data,
                 "media": {
                     "type": media_type

--- a/pytest_bdd/feature.py
+++ b/pytest_bdd/feature.py
@@ -548,12 +548,7 @@ class Step(object):
         :param data: actual data of Attachment, can be plain text or base64 encoded
         :param media_type: actual media type of Attachment, such as text/plain, image/png
         """
-        json_attachment = {
-                "data": data,
-                "media": {
-                    "type": media_type
-                }
-            }
+        json_attachment = {"data": data, "media": {"type": media_type}}
         self.embeddings.append(json_attachment)
 
     @property

--- a/pytest_bdd/reporting.py
+++ b/pytest_bdd/reporting.py
@@ -33,6 +33,7 @@ class StepReport(object):
         """
         return {
             "name": self.step.name,
+            "embeddings": self.step.embeddings,
             "type": self.step.type,
             "keyword": self.step.keyword,
             "line_number": self.step.line_number,

--- a/tests/feature/test_cucumber_json.py
+++ b/tests/feature/test_cucumber_json.py
@@ -124,6 +124,7 @@ def test_step_trace(testdir):
                     "steps": [
                         {
                             "keyword": "Given",
+                            "embeddings": [],
                             "line": 6,
                             "match": {"location": ""},
                             "name": "a passing step",
@@ -131,6 +132,7 @@ def test_step_trace(testdir):
                         },
                         {
                             "keyword": "And",
+                            "embeddings": [],
                             "line": 7,
                             "match": {"location": ""},
                             "name": "some other passing step",
@@ -149,6 +151,7 @@ def test_step_trace(testdir):
                     "steps": [
                         {
                             "keyword": "Given",
+                            "embeddings": [],
                             "line": 11,
                             "match": {"location": ""},
                             "name": "a passing step",
@@ -156,6 +159,7 @@ def test_step_trace(testdir):
                         },
                         {
                             "keyword": "And",
+                            "embeddings": [],
                             "line": 12,
                             "match": {"location": ""},
                             "name": "a failing step",
@@ -176,6 +180,7 @@ def test_step_trace(testdir):
                     "steps": [
                         {
                             "line": 16,
+                            "embeddings": [],
                             "match": {"location": ""},
                             "result": {"status": "passed", "duration": equals_any(int)},
                             "keyword": "Given",
@@ -212,6 +217,7 @@ def test_step_trace(testdir):
                     "steps": [
                         {
                             "line": 16,
+                            "embeddings": [],
                             "match": {"location": ""},
                             "result": {"status": "passed", "duration": equals_any(int)},
                             "keyword": "Given",

--- a/tests/feature/test_cucumber_json.py
+++ b/tests/feature/test_cucumber_json.py
@@ -199,6 +199,7 @@ def test_step_trace(testdir):
                     "steps": [
                         {
                             "line": 16,
+                            "embeddings": [],
                             "match": {"location": ""},
                             "result": {"status": "passed", "duration": equals_any(int)},
                             "keyword": "Given",

--- a/tests/feature/test_report.py
+++ b/tests/feature/test_report.py
@@ -122,6 +122,7 @@ def test_step_trace(testdir):
         "steps": [
             {
                 "duration": equals_any(float),
+                "embeddings": [],
                 "failed": False,
                 "keyword": "Given",
                 "line_number": 6,
@@ -130,6 +131,7 @@ def test_step_trace(testdir):
             },
             {
                 "duration": equals_any(float),
+                "embeddings": [],
                 "failed": False,
                 "keyword": "And",
                 "line_number": 7,
@@ -159,6 +161,7 @@ def test_step_trace(testdir):
         "steps": [
             {
                 "duration": equals_any(float),
+                "embeddings": [],
                 "failed": False,
                 "keyword": "Given",
                 "line_number": 11,
@@ -167,6 +170,7 @@ def test_step_trace(testdir):
             },
             {
                 "duration": equals_any(float),
+                "embeddings": [],
                 "failed": True,
                 "keyword": "And",
                 "line_number": 12,
@@ -195,6 +199,7 @@ def test_step_trace(testdir):
         "steps": [
             {
                 "duration": equals_any(float),
+                "embeddings": [],
                 "failed": False,
                 "keyword": "Given",
                 "line_number": 15,
@@ -203,6 +208,7 @@ def test_step_trace(testdir):
             },
             {
                 "duration": equals_any(float),
+                "embeddings": [],
                 "failed": False,
                 "keyword": "When",
                 "line_number": 16,
@@ -211,6 +217,7 @@ def test_step_trace(testdir):
             },
             {
                 "duration": equals_any(float),
+                "embeddings": [],
                 "failed": False,
                 "keyword": "Then",
                 "line_number": 17,
@@ -246,6 +253,7 @@ def test_step_trace(testdir):
         "steps": [
             {
                 "duration": equals_any(float),
+                "embeddings": [],
                 "failed": False,
                 "keyword": "Given",
                 "line_number": 15,
@@ -254,6 +262,7 @@ def test_step_trace(testdir):
             },
             {
                 "duration": equals_any(float),
+                "embeddings": [],
                 "failed": False,
                 "keyword": "When",
                 "line_number": 16,
@@ -262,6 +271,7 @@ def test_step_trace(testdir):
             },
             {
                 "duration": equals_any(float),
+                "embeddings": [],
                 "failed": False,
                 "keyword": "Then",
                 "line_number": 17,


### PR DESCRIPTION
### Description:

* Fix https://github.com/pytest-dev/pytest-bdd/issues/234,  add scenario.attach method

* Added scenario.attach method, so that you can add comments and/or screenshots to the cucumber-report.json file, and then you can convert the .json file to HTML report file

* Referred to this https://github.com/gkushang/cucumber-html-reporter/blob/4ed7e774f93c54ecd71a051d414a6d30305694ec/lib/reporter.js , which will convert step.embeddings to `Show Info+`

### An example usage: 
1. update your conftest.py by implementing the hook: pytest_bdd_after_scenario
https://gist.github.com/kenhosr/3cb60efce5481d25967479e67f7edb76

2. run your test using: pytest --cucumber-json=cucumber_report.json

3. convert the .json to .html by following instructions here:
https://github.com/gkushang/cucumber-html-reporter

### Sample Report:
![comments](https://user-images.githubusercontent.com/10588269/66495050-a10cd200-ea86-11e9-9af8-5d559fb2430f.png)

