### PR TITLE
Fix for Python 4

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -18,6 +18,7 @@ These people have contributed to `pytest-bdd`, in alphabetical order:
 * `Florian Bruhin <me@the-compiler.org>`_
 * `Floris Bruynooghe <flub@devork.be>`_
 * `Harro van der Klauw <hvdklauw@gmail.com>`_
+* `Hugo van Kemenade <https://github.com/hugovk>`_
 * `Laurence Rowe <l@lrowe.co.uk>`_
 * `Leonardo Santagada <santagada@github.com>`_
 * `Milosz Sliwinski <sliwinski-milosz>`_

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Changelog
 Unreleased
 ----------
 
+- Drop support for pytest < 4.3.
+- Fix a Python 4.0 bug.
 - Fix ``pytest --generate-missing`` functionality being broken.
 
 3.2.1

--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,7 @@ Install pytest-bdd
     pip install pytest-bdd
 
 
-The minimum required version of pytest is 3.3.2
+The minimum required version of pytest is 4.3.
 
 
 Example

--- a/pytest_bdd/cucumber_json.py
+++ b/pytest_bdd/cucumber_json.py
@@ -7,12 +7,7 @@ import os
 import sys
 import time
 
-import six
-
 from .feature import force_unicode
-
-if not six.PY2:
-    long = int
 
 
 def add_options(parser):
@@ -80,7 +75,7 @@ class LogBDDCucumberJSON(object):
             result = {"status": "failed", "error_message": force_unicode(report.longrepr) if error_message else ""}
         elif report.skipped:
             result = {"status": "skipped"}
-        result["duration"] = long(math.floor((10 ** 9) * step["duration"]))  # nanosec
+        result["duration"] = int(math.floor((10 ** 9) * step["duration"]))  # nanosec
         return result
 
     def _serialize_tags(self, item):

--- a/pytest_bdd/cucumber_json.py
+++ b/pytest_bdd/cucumber_json.py
@@ -11,7 +11,7 @@ import six
 
 from .feature import force_unicode
 
-if six.PY3:
+if not six.PY2:
     long = int
 
 

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ setup(
     ]
     + [("Programming Language :: Python :: %s" % x) for x in "2.7 3.4 3.5 3.6 3.7".split()],
     cmdclass={"test": ToxTestCommand},
-    install_requires=["glob2", "Mako", "parse", "parse_type", "py", "pytest>=3.0.0", "six>=1.9.0"],
+    install_requires=["glob2", "Mako", "parse", "parse_type", "py", "pytest>=4.3", "six>=1.9.0"],
     # the following makes a plugin available to py.test
     entry_points={
         "pytest11": ["pytest-bdd = pytest_bdd.plugin"],

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 distshare = {homedir}/.tox/distshare
 envlist = py37-pytestlatest-linters,
-          py27-pytest{36,37,38,39,310,4,41,42,43,44,45,46}-coverage,
-          py37-pytest{36,37,38,39,310,4,41,42,43,44,45,46,5,51,latest}-coverage,
+          py27-pytest{43,44,45,46}-coverage,
+          py37-pytest{43,44,45,46,5,51,latest}-coverage,
           py{35,36,38}-pytestlatest-coverage,
           py27-pytestlatest-xdist-coverage
 skip_missing_interpreters = true
@@ -19,14 +19,6 @@ deps =
     pytest45: pytest~=4.5.0
     pytest44: pytest~=4.4.0
     pytest43: pytest~=4.3.0
-    pytest42: pytest~=4.2.0
-    pytest41: pytest~=4.1.0
-    pytest4: pytest~=4.0.0
-    pytest310: pytest~=3.10.0
-    pytest39: pytest~=3.9.0
-    pytest38: pytest~=3.8.0
-    pytest37: pytest~=3.7.0
-    pytest36: pytest~=3.6.0
 
     coverage: coverage
     xdist: pytest-xdist


### PR DESCRIPTION
We don't yet know if 3.10 or 4.0 will follow Python 3.9, but whichever it is, it will probably happen in [2020 when Python 3.9 reaches beta](https://www.python.org/dev/peps/pep-0596/#schedule) and work begins on Python 3.9+1.

There's some code which uses `six.PY3`:

```python
if six.PY3:
    long = int
```

Where:

```python
PY3 = sys.version_info[0] == 3
```

When run on Python 4, this skip the line! Instead, use `not six.PY2`.

Found using https://github.com/asottile/flake8-2020:
```console
$ pip install -U flake8-2020
$ flake8 --select YTT
```
