### PR TITLE
Added gherkin reporting substitution for outline scenarios

### DIFF
--- a/pytest_bdd/feature.py
+++ b/pytest_bdd/feature.py
@@ -57,9 +57,8 @@ STEP_PREFIXES = [
     ("But ", None),
 ]
 
-STEP_PARAM_RE = re.compile(r"\<(.+?)\>")
+OUTLINE_PARAM_RE = re.compile(r"\<(.+?)\>")
 COMMENT_RE = re.compile(r'(^|(?<=\s))#')
-
 
 def get_step_type(line):
     """Detect step type by the beginning of the line.
@@ -541,7 +540,7 @@ class Step(object):
     @property
     def params(self):
         """Get step params."""
-        return tuple(frozenset(STEP_PARAM_RE.findall(self.name)))
+        return tuple(frozenset(OUTLINE_PARAM_RE.findall(self.name)))
 
 
 class Background(object):

--- a/pytest_bdd/gherkin_terminal_reporter.py
+++ b/pytest_bdd/gherkin_terminal_reporter.py
@@ -6,7 +6,7 @@ import re
 
 from _pytest.terminal import TerminalReporter
 
-from .feature import STEP_PARAM_RE
+from .feature import OUTLINE_PARAM_RE
 
 
 def add_options(parser):
@@ -76,7 +76,7 @@ class GherkinTerminalReporter(TerminalReporter):
                 word_markup = {'yellow': True}
         feature_markup = {'blue': True}
         scenario_markup = word_markup
-
+  
         if self.verbosity <= 0:
             return TerminalReporter.pytest_runtest_logreport(self, rep)
         elif self.verbosity == 1:
@@ -98,12 +98,17 @@ class GherkinTerminalReporter(TerminalReporter):
                 self._tw.write('Feature: ', **feature_markup)
                 self._tw.write(report.scenario['feature']['name'], **feature_markup)
                 self._tw.write('\n')
+                scenario_name = ''
+                if self.config.option.expand:
+                    scenario_name = self._format_outline_name(report.scenario['name'], **report.scenario['example_kwargs'])
+                else:
+                    scenario_name = report.scenario['name']
                 self._tw.write('    Scenario: ', **scenario_markup)
-                self._tw.write(report.scenario['name'], **scenario_markup)
-                self._tw.write('\n')
+                self._tw.write('{}\n'.format(scenario_name), **scenario_markup)
+
                 for step in report.scenario['steps']:
                     if self.config.option.expand:
-                        step_name = self._format_step_name(step['name'], **report.scenario['example_kwargs'])
+                        step_name = self._format_outline_name(step['name'], **report.scenario['example_kwargs'])
                     else:
                         step_name = step['name']
                     self._tw.write('        {} {}\n'.format(step['keyword'],
@@ -114,13 +119,13 @@ class GherkinTerminalReporter(TerminalReporter):
                 return TerminalReporter.pytest_runtest_logreport(self, rep)
         self.stats.setdefault(cat, []).append(rep)
 
-    def _format_step_name(self, step_name, **example_kwargs):
+    def _format_outline_name(self, outline_name, **example_kwargs):
         while True:
-            param_match = re.search(STEP_PARAM_RE, step_name)
+            param_match = re.search(OUTLINE_PARAM_RE, outline_name)
             if not param_match:
                 break
             param_token = param_match.group(0)
             param_name = param_match.group(1)
             param_value = example_kwargs[param_name]
-            step_name = step_name.replace(param_token, param_value)
-        return step_name
+            outline_name = outline_name.replace(param_token, param_value)
+        return outline_name

--- a/tests/feature/outline.feature
+++ b/tests/feature/outline.feature
@@ -1,4 +1,4 @@
-Scenario Outline: Outlined given, when, thens
+Scenario Outline: Outlined given when thens <start>
     Given there are <start> cucumbers
     When I eat <eat> cucumbers
     Then I should have <left> cucumbers

--- a/tests/feature/outline_feature.feature
+++ b/tests/feature/outline_feature.feature
@@ -5,7 +5,7 @@ Feature: Outline
     |  12   |  5  |  7   |
     |  5    |  4  |  1   |
 
-    Scenario Outline: Outlined given, when, thens
+    Scenario Outline: Outlined given when thens <start>
         Given there are <start> <fruits>
         When I eat <eat> <fruits>
         Then I should have <left> <fruits>

--- a/tests/feature/test_outline.py
+++ b/tests/feature/test_outline.py
@@ -8,10 +8,9 @@ from pytest_bdd import given, when, then, scenario
 from pytest_bdd import exceptions
 from pytest_bdd.utils import get_parametrize_markers_args
 
-
 @scenario(
     'outline.feature',
-    'Outlined given, when, thens',
+    'Outlined given when thens <start>',
     example_converters=dict(start=int, eat=float, left=str)
 )
 def test_outlined(request):
@@ -122,7 +121,7 @@ def other_fixture(request):
 
 @scenario(
     'outline.feature',
-    'Outlined given, when, thens',
+    'Outlined given when thens <start>',
     example_converters=dict(start=int, eat=float, left=str)
 )
 def test_outlined_with_other_fixtures(other_fixture):
@@ -162,7 +161,7 @@ def should_have_left_fruits(start_fruits, start, eat, left, fruits):
 
 @scenario(
     'outline_feature.feature',
-    'Outlined given, when, thens',
+    'Outlined given when thens <start>',
     example_converters=dict(start=int, eat=float, left=str)
 )
 def test_outlined_feature(request):


### PR DESCRIPTION
Needed gherkin reporting in a project to be able to substitute example fields in reports. Added capability. 

Some tests on parameters fail but are fixed in this branch on a different fork. 

'gherkin_reporter_parametrized_tests_fix' of github.com:sliwinski-milosz/pytest-bdd
