### PR TITLE
Override language

### DIFF
--- a/pytest_bdd/cucumber_json.py
+++ b/pytest_bdd/cucumber_json.py
@@ -50,7 +50,6 @@ def unconfigure(config):
 
 
 class LogBDDCucumberJSON(object):
-
     """Logging plugin for cucumber like json output."""
 
     def __init__(self, logfile, expand=False):
@@ -73,7 +72,8 @@ class LogBDDCucumberJSON(object):
         if report.passed or not step["failed"]:  # ignore setup/teardown
             result = {"status": "passed"}
         elif report.failed and step["failed"]:
-            result = {"status": "failed", "error_message": feature.force_unicode(report.longrepr) if error_message else ""}
+            result = {"status": "failed",
+                      "error_message": feature.force_unicode(report.longrepr) if error_message else ""}
         elif report.skipped:
             result = {"status": "skipped"}
         result["duration"] = int(math.floor((10 ** 9) * step["duration"]))  # nanosec
@@ -145,7 +145,6 @@ class LogBDDCucumberJSON(object):
 
         feature_label = '{}'.format(feature.prefix_by_type(types.FEATURE)).split(":")[0]
         scenario_label = '{}'.format(feature.prefix_by_type(types.SCENARIO)).split(":")[0]
-
 
         if scenario["feature"]["filename"] not in self.features:
             self.features[scenario["feature"]["filename"]] = {

--- a/pytest_bdd/cucumber_json.py
+++ b/pytest_bdd/cucumber_json.py
@@ -7,7 +7,8 @@ import os
 import sys
 import time
 
-from .feature import force_unicode
+from . import feature
+from . import types
 
 
 def add_options(parser):
@@ -72,7 +73,7 @@ class LogBDDCucumberJSON(object):
         if report.passed or not step["failed"]:  # ignore setup/teardown
             result = {"status": "passed"}
         elif report.failed and step["failed"]:
-            result = {"status": "failed", "error_message": force_unicode(report.longrepr) if error_message else ""}
+            result = {"status": "failed", "error_message": feature.force_unicode(report.longrepr) if error_message else ""}
         elif report.skipped:
             result = {"status": "skipped"}
         result["duration"] = int(math.floor((10 ** 9) * step["duration"]))  # nanosec
@@ -142,9 +143,13 @@ class LogBDDCucumberJSON(object):
                 "result": self._get_result(step, report, error_message),
             }
 
+        feature_label = '{}'.format(feature.prefix_by_type(types.FEATURE)).split(":")[0]
+        scenario_label = '{}'.format(feature.prefix_by_type(types.SCENARIO)).split(":")[0]
+
+
         if scenario["feature"]["filename"] not in self.features:
             self.features[scenario["feature"]["filename"]] = {
-                "keyword": "Feature",
+                "keyword": feature_label,
                 "uri": scenario["feature"]["rel_filename"],
                 "name": scenario["feature"]["name"] or scenario["feature"]["rel_filename"],
                 "id": scenario["feature"]["rel_filename"].lower().replace(" ", "-"),
@@ -156,7 +161,7 @@ class LogBDDCucumberJSON(object):
 
         self.features[scenario["feature"]["filename"]]["elements"].append(
             {
-                "keyword": "Scenario",
+                "keyword": scenario_label,
                 "id": report.item["name"],
                 "name": scenario["name"],
                 "line": scenario["line_number"],

--- a/pytest_bdd/feature.py
+++ b/pytest_bdd/feature.py
@@ -36,10 +36,8 @@ import six
 from . import types
 from . import exceptions
 
-
 # Global features dictionary
 features = {}
-
 
 STEP_PREFIXES = [
     ("Feature: ", types.FEATURE),
@@ -96,7 +94,7 @@ def parse_line(line):
     """
     for prefix, _ in STEP_PREFIXES:
         if line.startswith(prefix):
-            return prefix.strip(), line[len(prefix) :].strip()
+            return prefix.strip(), line[len(prefix):].strip()
     return "", line
 
 
@@ -175,7 +173,6 @@ def get_features(paths, **kwargs):
 
 
 class Examples(object):
-
     """Example table."""
 
     def __init__(self):
@@ -250,7 +247,6 @@ class Examples(object):
 
 
 class Feature(object):
-
     """Feature."""
 
     def __init__(self, basedir, filename, encoding="utf-8", strict_gherkin=True):
@@ -308,29 +304,29 @@ class Feature(object):
 
                 if strict_gherkin:
                     if (
-                        self.background
-                        and not scenario
-                        and mode not in (types.SCENARIO, types.SCENARIO_OUTLINE, types.GIVEN, types.TAG)
+                            self.background
+                            and not scenario
+                            and mode not in (types.SCENARIO, types.SCENARIO_OUTLINE, types.GIVEN, types.TAG)
                     ):
                         raise exceptions.FeatureError(
                             "Background section can only contain Given steps", line_number, clean_line, filename
                         )
 
                     if mode == types.GIVEN and prev_mode not in (
-                        types.GIVEN,
-                        types.SCENARIO,
-                        types.SCENARIO_OUTLINE,
-                        types.BACKGROUND,
+                            types.GIVEN,
+                            types.SCENARIO,
+                            types.SCENARIO_OUTLINE,
+                            types.BACKGROUND,
                     ):
                         raise exceptions.FeatureError(
                             "Given steps must be the first within the Scenario", line_number, clean_line, filename
                         )
 
                     if mode == types.WHEN and prev_mode not in (
-                        types.SCENARIO,
-                        types.SCENARIO_OUTLINE,
-                        types.GIVEN,
-                        types.WHEN,
+                            types.SCENARIO,
+                            types.SCENARIO_OUTLINE,
+                            types.GIVEN,
+                            types.WHEN,
                     ):
                         raise exceptions.FeatureError(
                             "When steps must be the first or follow Given steps", line_number, clean_line, filename
@@ -433,7 +429,6 @@ class Feature(object):
 
 
 class Scenario(object):
-
     """Scenario."""
 
     def __init__(self, feature, name, line_number, example_converters=None, tags=None):
@@ -511,7 +506,6 @@ class Scenario(object):
 
 @six.python_2_unicode_compatible
 class Step(object):
-
     """Step."""
 
     def __init__(self, name, type, indent, line_number, keyword):
@@ -564,7 +558,6 @@ class Step(object):
 
 
 class Background(object):
-
     """Background."""
 
     def __init__(self, feature, line_number):
@@ -582,10 +575,10 @@ class Background(object):
         step.background = self
         self.steps.append(step)
 
-def prefix_by_type(reqtype):
 
+def prefix_by_type(requested_type):
     for prefix, _type in STEP_PREFIXES:
-        if _type==reqtype:
+        if requested_type == _type:
             return prefix
 
-    return '<N/A type> {}'.format(reqtype)
+    return '<N/A type> {}'.format(requested_type)

--- a/pytest_bdd/feature.py
+++ b/pytest_bdd/feature.py
@@ -581,3 +581,11 @@ class Background(object):
         """Add step to the background."""
         step.background = self
         self.steps.append(step)
+
+def prefix_by_type(reqtype):
+
+    for prefix, _type in STEP_PREFIXES:
+        if _type==reqtype:
+            return prefix
+
+    return '<N/A type> {}'.format(reqtype)

--- a/pytest_bdd/gherkin_terminal_reporter.py
+++ b/pytest_bdd/gherkin_terminal_reporter.py
@@ -6,7 +6,9 @@ import re
 
 from _pytest.terminal import TerminalReporter
 
-from .feature import STEP_PARAM_RE
+from . import feature
+
+from . import types
 
 
 def add_options(parser):
@@ -77,15 +79,18 @@ class GherkinTerminalReporter(TerminalReporter):
         feature_markup = {"blue": True}
         scenario_markup = word_markup
 
+        feature_label = '{}'.format(feature.prefix_by_type(types.FEATURE))
+        scenario_label = '    {}'.format(feature.prefix_by_type(types.SCENARIO))
+
         if self.verbosity <= 0:
             return TerminalReporter.pytest_runtest_logreport(self, rep)
         elif self.verbosity == 1:
             if hasattr(report, "scenario"):
                 self.ensure_newline()
-                self._tw.write("Feature: ", **feature_markup)
+                self._tw.write(feature_label, **feature_markup)
                 self._tw.write(report.scenario["feature"]["name"], **feature_markup)
                 self._tw.write("\n")
-                self._tw.write("    Scenario: ", **scenario_markup)
+                self._tw.write(scenario_label, **scenario_markup)
                 self._tw.write(report.scenario["name"], **scenario_markup)
                 self._tw.write(" ")
                 self._tw.write(word, **word_markup)
@@ -95,10 +100,10 @@ class GherkinTerminalReporter(TerminalReporter):
         elif self.verbosity > 1:
             if hasattr(report, "scenario"):
                 self.ensure_newline()
-                self._tw.write("Feature: ", **feature_markup)
+                self._tw.write(feature_label, **feature_markup)
                 self._tw.write(report.scenario["feature"]["name"], **feature_markup)
                 self._tw.write("\n")
-                self._tw.write("    Scenario: ", **scenario_markup)
+                self._tw.write(scenario_label, **scenario_markup)
                 self._tw.write(report.scenario["name"], **scenario_markup)
                 self._tw.write("\n")
                 for step in report.scenario["steps"]:
@@ -115,7 +120,7 @@ class GherkinTerminalReporter(TerminalReporter):
 
     def _format_step_name(self, step_name, **example_kwargs):
         while True:
-            param_match = re.search(STEP_PARAM_RE, step_name)
+            param_match = re.search(feature.STEP_PARAM_RE, step_name)
             if not param_match:
                 break
             param_token = param_match.group(0)


### PR DESCRIPTION
When we override the language by redefining the "types" constants, the terminal reporting as well as the cucumber.json output does not follow as expected. 
Although this is not an I18N proper solution, it allows one to override the types constants and even so the reporting tools work in consistent fashion.