### PR TITLE
Override language

### DIFF
--- a/pytest_bdd/cucumber_json.py
+++ b/pytest_bdd/cucumber_json.py
@@ -148,7 +148,6 @@ class LogBDDCucumberJSON(object):
 
         feature_label = "{}".format(feature.prefix_by_type(types.FEATURE)).split(":")[0]
         scenario_label = "{}".format(feature.prefix_by_type(types.SCENARIO)).split(":")[0]
-
         if scenario["feature"]["filename"] not in self.features:
             self.features[scenario["feature"]["filename"]] = {
                 "keyword": feature_label,

--- a/pytest_bdd/cucumber_json.py
+++ b/pytest_bdd/cucumber_json.py
@@ -73,7 +73,10 @@ class LogBDDCucumberJSON(object):
         if report.passed or not step["failed"]:  # ignore setup/teardown
             result = {"status": "passed"}
         elif report.failed and step["failed"]:
-            result = {"status": "failed", "error_message": feature.force_unicode(report.longrepr) if error_message else ""}
+            result = {
+                "status": "failed",
+                "error_message": feature.force_unicode(report.longrepr) if error_message else "",
+            }
         elif report.skipped:
             result = {"status": "skipped"}
         result["duration"] = int(math.floor((10 ** 9) * step["duration"]))  # nanosec
@@ -143,9 +146,8 @@ class LogBDDCucumberJSON(object):
                 "result": self._get_result(step, report, error_message),
             }
 
-        feature_label = '{}'.format(feature.prefix_by_type(types.FEATURE)).split(":")[0]
-        scenario_label = '{}'.format(feature.prefix_by_type(types.SCENARIO)).split(":")[0]
-
+        feature_label = "{}".format(feature.prefix_by_type(types.FEATURE)).split(":")[0]
+        scenario_label = "{}".format(feature.prefix_by_type(types.SCENARIO)).split(":")[0]
 
         if scenario["feature"]["filename"] not in self.features:
             self.features[scenario["feature"]["filename"]] = {

--- a/pytest_bdd/cucumber_json.py
+++ b/pytest_bdd/cucumber_json.py
@@ -7,7 +7,8 @@ import os
 import sys
 import time
 
-from .feature import force_unicode
+from . import feature
+from . import types
 
 
 def add_options(parser):
@@ -72,7 +73,7 @@ class LogBDDCucumberJSON(object):
         if report.passed or not step["failed"]:  # ignore setup/teardown
             result = {"status": "passed"}
         elif report.failed and step["failed"]:
-            result = {"status": "failed", "error_message": force_unicode(report.longrepr) if error_message else ""}
+            result = {"status": "failed", "error_message": feature.force_unicode(report.longrepr) if error_message else ""}
         elif report.skipped:
             result = {"status": "skipped"}
         result["duration"] = int(math.floor((10 ** 9) * step["duration"]))  # nanosec
@@ -142,9 +143,13 @@ class LogBDDCucumberJSON(object):
                 "result": self._get_result(step, report, error_message),
             }
 
+        feature_label = '{}'.format(feature.prefix_by_type(types.FEATURE)).split(":")[0]
+        scenario_label = '{}'.format(feature.prefix_by_type(types.SCENARIO)).split(":")[0]
+
+
         if scenario["feature"]["filename"] not in self.features:
             self.features[scenario["feature"]["filename"]] = {
-                "keyword": "Feature",
+                "keyword": feature_label,
                 "uri": scenario["feature"]["rel_filename"],
                 "name": scenario["feature"]["name"] or scenario["feature"]["rel_filename"],
                 "id": scenario["feature"]["rel_filename"].lower().replace(" ", "-"),
@@ -156,7 +161,7 @@ class LogBDDCucumberJSON(object):
 
         self.features[scenario["feature"]["filename"]]["elements"].append(
             {
-                "keyword": "Scenario",
+                "keyword": scenario_label,
                 "id": report.item["name"],
                 "name": scenario["name"],
                 "line": scenario["line_number"],

--- a/pytest_bdd/cucumber_json.py
+++ b/pytest_bdd/cucumber_json.py
@@ -7,6 +7,7 @@ import os
 import sys
 import time
 
+from .feature import force_unicode
 from . import feature
 from . import types
 
@@ -73,10 +74,7 @@ class LogBDDCucumberJSON(object):
         if report.passed or not step["failed"]:  # ignore setup/teardown
             result = {"status": "passed"}
         elif report.failed and step["failed"]:
-            result = {
-                "status": "failed",
-                "error_message": feature.force_unicode(report.longrepr) if error_message else "",
-            }
+            result = {"status": "failed", "error_message": force_unicode(report.longrepr) if error_message else ""}
         elif report.skipped:
             result = {"status": "skipped"}
         result["duration"] = int(math.floor((10 ** 9) * step["duration"]))  # nanosec

--- a/pytest_bdd/feature.py
+++ b/pytest_bdd/feature.py
@@ -582,10 +582,11 @@ class Background(object):
         step.background = self
         self.steps.append(step)
 
+
 def prefix_by_type(reqtype):
 
     for prefix, _type in STEP_PREFIXES:
-        if _type==reqtype:
+        if _type == reqtype:
             return prefix
 
-    return '<N/A type> {}'.format(reqtype)
+    return "<N/A type> {}".format(reqtype)

--- a/pytest_bdd/feature.py
+++ b/pytest_bdd/feature.py
@@ -581,3 +581,11 @@ class Background(object):
         """Add step to the background."""
         step.background = self
         self.steps.append(step)
+
+def prefix_by_type(reqtype):
+
+    for prefix, _type in STEP_PREFIXES:
+        if _type==reqtype:
+            return prefix
+
+    return '<N/A type> {}'.format(reqtype)

--- a/pytest_bdd/gherkin_terminal_reporter.py
+++ b/pytest_bdd/gherkin_terminal_reporter.py
@@ -6,7 +6,9 @@ import re
 
 from _pytest.terminal import TerminalReporter
 
-from .feature import STEP_PARAM_RE
+from . import feature
+
+from . import types
 
 
 def add_options(parser):
@@ -77,15 +79,18 @@ class GherkinTerminalReporter(TerminalReporter):
         feature_markup = {"blue": True}
         scenario_markup = word_markup
 
+        feature_label = '{}'.format(feature.prefix_by_type(types.FEATURE))
+        scenario_label = '    {}'.format(feature.prefix_by_type(types.SCENARIO))
+
         if self.verbosity <= 0:
             return TerminalReporter.pytest_runtest_logreport(self, rep)
         elif self.verbosity == 1:
             if hasattr(report, "scenario"):
                 self.ensure_newline()
-                self._tw.write("Feature: ", **feature_markup)
+                self._tw.write(feature_label, **feature_markup)
                 self._tw.write(report.scenario["feature"]["name"], **feature_markup)
                 self._tw.write("\n")
-                self._tw.write("    Scenario: ", **scenario_markup)
+                self._tw.write(scenario_label, **scenario_markup)
                 self._tw.write(report.scenario["name"], **scenario_markup)
                 self._tw.write(" ")
                 self._tw.write(word, **word_markup)
@@ -95,10 +100,10 @@ class GherkinTerminalReporter(TerminalReporter):
         elif self.verbosity > 1:
             if hasattr(report, "scenario"):
                 self.ensure_newline()
-                self._tw.write("Feature: ", **feature_markup)
+                self._tw.write(feature_label, **feature_markup)
                 self._tw.write(report.scenario["feature"]["name"], **feature_markup)
                 self._tw.write("\n")
-                self._tw.write("    Scenario: ", **scenario_markup)
+                self._tw.write(scenario_label, **scenario_markup)
                 self._tw.write(report.scenario["name"], **scenario_markup)
                 self._tw.write("\n")
                 for step in report.scenario["steps"]:
@@ -115,7 +120,7 @@ class GherkinTerminalReporter(TerminalReporter):
 
     def _format_step_name(self, step_name, **example_kwargs):
         while True:
-            param_match = re.search(STEP_PARAM_RE, step_name)
+            param_match = re.search(feature.STEP_PARAM_RE, step_name)
             if not param_match:
                 break
             param_token = param_match.group(0)

--- a/pytest_bdd/gherkin_terminal_reporter.py
+++ b/pytest_bdd/gherkin_terminal_reporter.py
@@ -79,8 +79,8 @@ class GherkinTerminalReporter(TerminalReporter):
         feature_markup = {"blue": True}
         scenario_markup = word_markup
 
-        feature_label = '{}'.format(feature.prefix_by_type(types.FEATURE))
-        scenario_label = '    {}'.format(feature.prefix_by_type(types.SCENARIO))
+        feature_label = "{}".format(feature.prefix_by_type(types.FEATURE))
+        scenario_label = "    {}".format(feature.prefix_by_type(types.SCENARIO))
 
         if self.verbosity <= 0:
             return TerminalReporter.pytest_runtest_logreport(self, rep)

--- a/pytest_bdd/gherkin_terminal_reporter.py
+++ b/pytest_bdd/gherkin_terminal_reporter.py
@@ -6,6 +6,7 @@ import re
 
 from _pytest.terminal import TerminalReporter
 
+from .feature import STEP_PARAM_RE
 from . import feature
 from . import types
 

--- a/pytest_bdd/gherkin_terminal_reporter.py
+++ b/pytest_bdd/gherkin_terminal_reporter.py
@@ -119,7 +119,7 @@ class GherkinTerminalReporter(TerminalReporter):
 
     def _format_step_name(self, step_name, **example_kwargs):
         while True:
-            param_match = re.search(feature.STEP_PARAM_RE, step_name)
+            param_match = re.search(STEP_PARAM_RE, step_name)
             if not param_match:
                 break
             param_token = param_match.group(0)

--- a/pytest_bdd/gherkin_terminal_reporter.py
+++ b/pytest_bdd/gherkin_terminal_reporter.py
@@ -7,7 +7,6 @@ import re
 from _pytest.terminal import TerminalReporter
 
 from . import feature
-
 from . import types
 
 
@@ -81,7 +80,6 @@ class GherkinTerminalReporter(TerminalReporter):
 
         feature_label = "{}".format(feature.prefix_by_type(types.FEATURE))
         scenario_label = "    {}".format(feature.prefix_by_type(types.SCENARIO))
-
         if self.verbosity <= 0:
             return TerminalReporter.pytest_runtest_logreport(self, rep)
         elif self.verbosity == 1:

--- a/tests/feature/function.feature
+++ b/tests/feature/function.feature
@@ -1,0 +1,3 @@
+Feature: function 
+    Scenario: With function prefix_by_type
+When is called

--- a/tests/feature/test_function.py
+++ b/tests/feature/test_function.py
@@ -15,6 +15,6 @@ def test_when_function_is_called():
 
 
 @when("is called")
-def something():
+def is_called():
     assert feature.prefix_by_type(types.FEATURE) == """Feature: """
 

--- a/tests/feature/test_function.py
+++ b/tests/feature/test_function.py
@@ -7,8 +7,6 @@ from pytest_bdd import feature
 from pytest_bdd import types
 
 
-
-
 @scenario("function.feature", "With function prefix_by_type")
 def test_when_function_is_called():
     pass
@@ -17,4 +15,3 @@ def test_when_function_is_called():
 @when("is called")
 def is_called():
     assert feature.prefix_by_type(types.FEATURE) == """Feature: """
-

--- a/tests/feature/test_function.py
+++ b/tests/feature/test_function.py
@@ -2,9 +2,11 @@
 
 from pytest_bdd import scenario, when
 
-from . import feature
+from pytest_bdd import feature
 
-from . import types
+from pytest_bdd import types
+
+
 
 
 @scenario("function.feature", "With function prefix_by_type")

--- a/tests/feature/test_function.py
+++ b/tests/feature/test_function.py
@@ -15,3 +15,4 @@ def test_when_function_is_called():
 @when("is called")
 def is_called():
     assert feature.prefix_by_type(types.FEATURE) == """Feature: """
+    assert feature.prefix_by_type("NA") == """<N/A type> NA"""

--- a/tests/feature/test_function.py
+++ b/tests/feature/test_function.py
@@ -16,5 +16,5 @@ def test_when_function_is_called():
 
 @when("is called")
 def something():
-    assert feature.prefix_by_type(types.FEATURE) == """Feature"""
+    assert feature.prefix_by_type(types.FEATURE) == """Feature: """
 

--- a/tests/feature/test_function.py
+++ b/tests/feature/test_function.py
@@ -1,0 +1,18 @@
+"""Function name same as step name."""
+
+from pytest_bdd import scenario, when
+
+from . import feature
+
+from . import types
+
+
+@scenario("function.feature", "With function prefix_by_type")
+def test_when_function_is_called():
+    pass
+
+
+@when("is called")
+def something():
+    assert feature.prefix_by_type(types.FEATURE) == """Feature"""
+


### PR DESCRIPTION
When we override the language by redefining the "types" constants, the terminal reporting as well as the cucumber.json output does not follow as expected.
Although this is not an I18N proper solution, it allows one to override the types constants and even so the reporting tools work in consistent fashion.