### PR TITLE
Generate missing with parsers

### DIFF
--- a/pytest_bdd/generation.py
+++ b/pytest_bdd/generation.py
@@ -126,7 +126,7 @@ def _find_step_fixturedef(fixturemanager, item, name, type_, encoding="utf-8"):
         name = find_argumented_step_fixture_name(name, type_, fixturemanager)
         if name:
             # strip off the extra stuff before passing it back in
-            name = name.replace('{}{}_'.format(prefix, encoding),'')
+            name = name.replace("{}{}_".format(prefix, encoding), "")
             return _find_step_fixturedef(fixturemanager, item, name, encoding)
     else:
         return fixturedefs

--- a/pytest_bdd/generation.py
+++ b/pytest_bdd/generation.py
@@ -7,7 +7,7 @@ from mako.lookup import TemplateLookup
 import py
 
 from .scenario import find_argumented_step_fixture_name, make_python_docstring, make_python_name, make_string_literal
-from .steps import get_step_fixture_name
+from .steps import prefix, get_step_fixture_name
 from .feature import get_features
 from .types import STEP_TYPES
 
@@ -117,10 +117,16 @@ def _find_step_fixturedef(fixturemanager, item, name, type_, encoding="utf-8"):
 
     :return: Step function.
     """
-    fixturedefs = fixturemanager.getfixturedefs(get_step_fixture_name(name, type_, encoding), item.nodeid)
+    if name.startswith(prefix):
+        step_fixture_name = name
+    else:
+        step_fixture_name = get_step_fixture_name(name, type_, encoding)
+    fixturedefs = fixturemanager.getfixturedefs(step_fixture_name, item.nodeid)
     if not fixturedefs:
         name = find_argumented_step_fixture_name(name, type_, fixturemanager)
         if name:
+            # strip off the extra stuff before passing it back in
+            name = name.replace('{}{}_'.format(prefix, encoding),'')
             return _find_step_fixturedef(fixturemanager, item, name, encoding)
     else:
         return fixturedefs

--- a/pytest_bdd/steps.py
+++ b/pytest_bdd/steps.py
@@ -49,6 +49,9 @@ from .parsers import get_parser
 from .utils import get_args
 
 
+prefix = "pytestbdd_"
+
+
 def get_step_fixture_name(name, type_, encoding=None):
     """Get step fixture name.
 
@@ -58,8 +61,8 @@ def get_step_fixture_name(name, type_, encoding=None):
     :return: step fixture name
     :rtype: string
     """
-    return "pytestbdd_{type}_{name}".format(
-        type=type_, name=force_encode(name, **(dict(encoding=encoding) if encoding else {}))
+    return "{prefix}{type}_{name}".format(
+        prefix=prefix, type=type_, name=force_encode(name, **(dict(encoding=encoding) if encoding else {}))
     )
 
 

--- a/tests/generation/generation.feature
+++ b/tests/generation/generation.feature
@@ -10,6 +10,8 @@ Feature: Missing code generation
     Scenario: Code is generated for scenarios which are not bound to any tests
         Given I have a bar
 
+    Scenario: Scenario tests which are already bound to the tests stay as is, with parser
+        Given I have 20 bars
 
     Scenario: Code is generated for scenario steps which are not yet defined(implemented)
         Given I have a custom bar

--- a/tests/generation/test_generate_missing.py
+++ b/tests/generation/test_generate_missing.py
@@ -23,7 +23,7 @@ def test_generate_missing(testdir):
             """
         import functools
 
-        from pytest_bdd import scenario, given
+        from pytest_bdd import scenario, given, parsers
 
         scenario = functools.partial(scenario, "generation.feature")
 
@@ -31,12 +31,20 @@ def test_generate_missing(testdir):
         def i_have_a_bar():
             return "bar"
 
+        @given(parsers.parse("I have {bars:d} bars"))
+        def i_have_number_bars(bars):
+            return bars
+
         @scenario("Scenario tests which are already bound to the tests stay as is")
         def test_foo():
             pass
 
         @scenario("Code is generated for scenario steps which are not yet defined(implemented)")
         def test_missing_steps():
+            pass
+
+        @scenario("Scenario tests which are already bound to the tests stay as is, with parser")
+        def test_parsable_given():
             pass
     """
         )
@@ -58,6 +66,8 @@ def test_generate_missing(testdir):
     result.stdout.fnmatch_lines(
         ['Step Given "I have a foobar" is not defined in the background of the feature "Missing code generation" *']
     )
+
+    assert 'Step Given "I have 20 bars" is not defined' not in result.stdout.str()
 
     result.stdout.fnmatch_lines(["Please place the code above to the test file(s):"])
 


### PR DESCRIPTION
The `--generate-missing` argument to pytest does not recognize given/when/then clauses that are implemented using a parser from the parsers module. However, the generation code was discovering them.  It just wasn't returning it as found due to a duplicate name prefix being applied.  

This PR removes that prefix in those cases, which allows `--generate-missing` to recognize parser clauses as NOT missing.