### PR TITLE
Parse multilines according to the gherkin specification

### DIFF
--- a/pytest_bdd/feature.py
+++ b/pytest_bdd/feature.py
@@ -545,7 +545,17 @@ class Step(object):
     @property
     def name(self):
         """Get step name."""
-        lines = [self._name] + ([textwrap.dedent("\n".join(self.lines))] if self.lines else [])
+        multilines_content = textwrap.dedent("\n".join(self.lines)) if self.lines else ""
+
+        # Remove the multiline quotes, if present.
+        multilines_content = re.sub(
+            pattern=r'^"""\n(?P<content>.*)\n"""$',
+            repl=r'\g<content>',
+            string=multilines_content,
+            flags=re.DOTALL,  # Needed to make the "." match also new liness
+        )
+
+        lines = [self._name] + [multilines_content]
         return "\n".join(lines).strip()
 
     @name.setter

--- a/pytest_bdd/feature.py
+++ b/pytest_bdd/feature.py
@@ -550,7 +550,7 @@ class Step(object):
         # Remove the multiline quotes, if present.
         multilines_content = re.sub(
             pattern=r'^"""\n(?P<content>.*)\n"""$',
-            repl=r'\g<content>',
+            repl=r"\g<content>",
             string=multilines_content,
             flags=re.DOTALL,  # Needed to make the "." match also new liness
         )

--- a/pytest_bdd/feature.py
+++ b/pytest_bdd/feature.py
@@ -552,7 +552,7 @@ class Step(object):
             pattern=r'^"""\n(?P<content>.*)\n"""$',
             repl=r"\g<content>",
             string=multilines_content,
-            flags=re.DOTALL,  # Needed to make the "." match also new liness
+            flags=re.DOTALL,  # Needed to make the "." match also new lines
         )
 
         lines = [self._name] + [multilines_content]

--- a/tests/feature/test_multiline.py
+++ b/tests/feature/test_multiline.py
@@ -11,66 +11,65 @@ from pytest_bdd import exceptions, given, parsers, scenario, then
     [
         (
             textwrap.dedent(
-                """
-        Scenario: Multiline step using sub indentation
-            Given I have a step with:
-                Some
-
-                Extra
-                Lines
-            Then the text should be parsed with correct indentation
-        """
+                '''\
+Feature: Multiline
+    Scenario: Multiline step using sub indentation
+        Given I have a step with:
+            """
+            Some
+    
+            Extra
+            Lines
+            """
+        Then the text should be parsed with correct indentation
+'''
             ),
-            textwrap.dedent(
-                """
-        Some
-
-        Extra
-        Lines
-        """
-            )[1:-1],
+            "Some\n\nExtra\nLines",
         ),
         (
             textwrap.dedent(
-                """
-        Scenario: Multiline step using sub indentation
-            Given I have a step with:
-                Some
-
-              Extra
-             Lines
-
-            Then the text should be parsed with correct indentation
-        """
+                """\
+Feature: Multiline
+    Scenario: Multiline step using sub indentation
+        Given I have a step with:
+            Some
+    
+            Extra
+            Lines
+        Then the text should be parsed with correct indentation
+"""
             ),
-            textwrap.dedent(
-                """
-           Some
-
-         Extra
-        Lines
-        """
-            )[1:-1],
+            "Some\n\nExtra\nLines",
         ),
         (
             textwrap.dedent(
-                """
-        Feature:
-        Scenario: Multiline step using sub indentation
-            Given I have a step with:
-                Some
-                Extra
-                Lines
+                """\
+Feature: Multiline
+    Scenario: Multiline step using sub indentation
+        Given I have a step with:
+            Some
 
-        """
+          Extra
+         Lines
+
+        Then the text should be parsed with correct indentation
+"""
             ),
+            "   Some\n\n Extra\nLines",
+        ),
+        (
             textwrap.dedent(
-                """
-        Some
-        Extra
-        Lines
-        """
-            )[1:-1],
+                """\
+Feature: Multiline
+    Scenario: Multiline step using sub indentation
+        Given I have a step with:
+            Some
+            Extra
+            Lines
+
+"""
+            ),
+            "Some\nExtra\nLines",
         ),
     ],
 )


### PR DESCRIPTION
The [gherkin documentation](https://cucumber.io/docs/gherkin/reference/#doc-strings) says that multiline steps should be enclosed by `"""` quotes.