### PR TITLE
Implement datatables

### DIFF
--- a/pytest_bdd/feature.py
+++ b/pytest_bdd/feature.py
@@ -1,9 +1,7 @@
 """Feature.
 
 The way of describing the behavior is based on Gherkin language, but a very
-limited version. It doesn't support any parameter tables.
-If the parametrization is needed to generate more test cases it can be done
-on the fixture level of the pytest.
+limited version.
 The <variable> syntax can be used here to make a connection between steps and
 it will also validate the parameters mentioned in the steps with ones
 provided in the pytest parametrization table.
@@ -19,8 +17,6 @@ Syntax example:
         And the article should be published  # Note: will query the database
 
 :note: The "#" symbol is used for comments.
-:note: There're no multiline steps, the description of the step must fit in
-one line.
 """
 
 from collections import OrderedDict
@@ -143,9 +139,9 @@ def get_tags(line):
 
 
 def split_line(line):
-    """Split the given Examples line.
+    """Split the given table line.
 
-    :param str|unicode line: Feature file Examples line.
+    :param str|unicode line: Feature file table line.
 
     :return: List of strings.
     """
@@ -174,15 +170,35 @@ def get_features(paths, **kwargs):
     return features
 
 
-class Examples(object):
+def is_table_line(line):
+    """Detect table line.
 
-    """Example table."""
+    :param `string` line: the line to inspect
+
+    :return: `bool`.
+    """
+    return line.startswith("|") and line.endswith("|")
+
+
+def parse_table_line(line):
+    """Parse cells contained in a table line.
+
+    :param `string` line: the line to parse (stripped)
+
+    :return: `string list`.
+    """
+    return [l for l in split_line(line)]
+
+
+class Table(object):
+
+    """Example or data table."""
 
     def __init__(self):
-        """Initialize examples instance."""
-        self.example_params = []
-        self.examples = []
-        self.vertical_examples = []
+        """Initialize table instance."""
+        self.params = []
+        self.entries = []
+        self.vertical_entries = []
         self.line_number = None
         self.name = None
 
@@ -191,62 +207,78 @@ class Examples(object):
 
         :param names: `list` of `string` parameter names.
         """
-        self.example_params = [str(key) for key in keys]
+        self.params = [str(key) for key in keys]
 
-    def add_example(self, values):
-        """Add example.
+    def add_row(self, values):
+        """Add a table row from a line in horizontal mode.
 
         :param values: `list` of `string` parameter values.
         """
-        self.examples.append(values)
+        self.entries.append(values)
 
-    def add_example_row(self, param, values):
-        """Add example row.
+    def add_col(self, param, values):
+        """Add a table column from a line in vertical mode.
 
         :param param: `str` parameter name
         :param values: `list` of `string` parameter values
         """
-        if param in self.example_params:
+        if param in self.params:
             raise exceptions.ExamplesNotValidError(
                 """Example rows should contain unique parameters. "{0}" appeared more than once""".format(param)
             )
-        self.example_params.append(param)
-        self.vertical_examples.append(values)
+        self.params.append(param)
+        self.vertical_entries.append(values)
 
     def get_params(self, converters, builtin=False):
         """Get scenario pytest parametrization table.
 
         :param converters: `dict` of converter functions to convert parameter values
         """
-        param_count = len(self.example_params)
-        if self.vertical_examples and not self.examples:
-            for value_index in range(len(self.vertical_examples[0])):
-                example = []
+        param_count = len(self.params)
+        if self.vertical_entries and not self.entries:
+            for value_index in range(len(self.vertical_entries[0])):
+                entry = []
                 for param_index in range(param_count):
-                    example.append(self.vertical_examples[param_index][value_index])
-                self.examples.append(example)
+                    entry.append(self.vertical_entries[param_index][value_index])
+                self.entries.append(entry)
 
-        if self.examples:
+        if self.entries:
             params = []
-            for example in self.examples:
-                example = list(example)
-                for index, param in enumerate(self.example_params):
-                    raw_value = example[index]
+            for entry in self.entries:
+                entry = list(entry)
+                for index, param in enumerate(self.params):
+                    raw_value = entry[index]
                     if converters and param in converters:
                         value = converters[param](raw_value)
                         if not builtin or value.__class__.__module__ in {"__builtin__", "builtins"}:
-                            example[index] = value
-                params.append(example)
-            return [self.example_params, params]
+                            entry[index] = value
+                params.append(entry)
+            return [self.params, params]
         else:
             return []
 
     def __bool__(self):
         """Bool comparison."""
-        return bool(self.vertical_examples or self.examples)
+        return bool(self.vertical_entries or self.entries)
 
     if six.PY2:
         __nonzero__ = __bool__
+
+
+class Examples(Table):
+    """Examples table
+    Used for Gherkin test parametrization of tests.
+    This is the same class as Table but with different name for easier
+    interactive debugging.
+    """
+
+
+class DataTable(Table):
+    """Data table
+    Used to provide fixture injection for steps.
+    This is the same class as Table but with different name for easier
+    interactive debugging.
+    """
 
 
 class Feature(object):
@@ -282,17 +314,26 @@ class Feature(object):
             content = force_unicode(f.read(), encoding)
             for line_number, line in enumerate(content.splitlines(), start=1):
                 unindented_line = line.lstrip()
+                stripped_line = line.strip()
+                clean_line = strip_comments(line)
                 line_indent = len(line) - len(unindented_line)
                 if step and (step.indent < line_indent or ((not unindented_line) and multiline_step)):
-                    multiline_step = True
-                    # multiline step, so just add line and continue
-                    step.add_line(line)
+                    if is_table_line(stripped_line):
+                        # This line is part of a data table attached to the
+                        # current step
+                        if step.datatable.params:
+                            # We already met the headers row
+                            step.datatable.add_row(parse_table_line(stripped_line))
+                        else:
+                            step.datatable.set_param_names(parse_table_line(stripped_line))
+                    else:
+                        multiline_step = True
+                        # multiline step, so just add line and continue
+                        step.add_line(line)
                     continue
                 else:
                     step = None
                     multiline_step = False
-                stripped_line = line.strip()
-                clean_line = strip_comments(line)
                 if not clean_line and (not prev_mode or prev_mode not in types.FEATURE):
                     continue
                 mode = get_step_type(clean_line) or mode
@@ -372,14 +413,14 @@ class Feature(object):
                     mode = types.EXAMPLE_LINE_VERTICAL
                     (scenario or self).examples.line_number = line_number
                 elif mode == types.EXAMPLES_HEADERS:
-                    (scenario or self).examples.set_param_names([l for l in split_line(parsed_line) if l])
+                    (scenario or self).examples.set_param_names(parse_table_line(parsed_line))
                     mode = types.EXAMPLE_LINE
                 elif mode == types.EXAMPLE_LINE:
-                    (scenario or self).examples.add_example([l for l in split_line(stripped_line)])
+                    (scenario or self).examples.add_row(parse_table_line(stripped_line))
                 elif mode == types.EXAMPLE_LINE_VERTICAL:
-                    param_line_parts = [l for l in split_line(stripped_line)]
+                    param_line_parts = parse_table_line(stripped_line)
                     try:
-                        (scenario or self).examples.add_example_row(param_line_parts[0], param_line_parts[1:])
+                        (scenario or self).examples.add_col(param_line_parts[0], param_line_parts[1:])
                     except exceptions.ExamplesNotValidError as exc:
                         if scenario:
                             raise exceptions.FeatureError(
@@ -486,7 +527,7 @@ class Scenario(object):
 
     def get_example_params(self):
         """Get example parameter names."""
-        return set(self.examples.example_params + self.feature.examples.example_params)
+        return set(self.examples.params + self.feature.examples.params)
 
     def get_params(self, builtin=False):
         """Get converted example params."""
@@ -534,6 +575,7 @@ class Step(object):
         self.stop = 0
         self.scenario = None
         self.background = None
+        self.datatable = DataTable()
 
     def add_line(self, line):
         """Add line to the multiple step.

--- a/pytest_bdd/scenario.py
+++ b/pytest_bdd/scenario.py
@@ -163,6 +163,8 @@ def _execute_scenario(feature, scenario, request, encoding):
                 )
                 raise
 
+            if step.datatable:
+                inject_fixture(request, "datatable", [step.datatable.params, step.datatable.entries])
             _execute_step_function(request, scenario, step, step_func)
     finally:
         request.config.hook.pytest_bdd_after_scenario(request=request, feature=feature, scenario=scenario)

--- a/pytest_bdd/steps.py
+++ b/pytest_bdd/steps.py
@@ -70,7 +70,7 @@ def given(name, fixture=None, converters=None, scope="function", target_fixture=
     :param fixture: Optional name of the fixture to reuse.
     :param converters: Optional `dict` of the argument or parameter converters in form
                        {<param_name>: <converter function>}.
-    :scope: Optional fixture scope
+    :param scope: Optional fixture scope
     :param target_fixture: Target fixture name to replace by steps definition function
     :raises: StepError in case of wrong configuration.
     :note: Can't be used as a decorator when the fixture is specified.

--- a/tests/feature/test_datatable.feature
+++ b/tests/feature/test_datatable.feature
@@ -1,0 +1,23 @@
+Feature: Datatables
+
+  Scenario Outline: I use datatables
+    Given the following users exist:
+      | name   | email              | twitter         |
+      | Aslak  | aslak@cucumber.io  | @aslak_hellesoy |
+      | Julien | julien@cucumber.io | @jbpros         |
+      | Matt   | matt@cucumber.io   | @mattwynne      |
+    Then I should see the following names:
+      | name   |
+      | Aslak  |
+      | Julien |
+      | Matt   |
+    And I should see the following emails:
+      | email              |
+      | aslak@cucumber.io  |
+      | julien@cucumber.io |
+      | matt@cucumber.io   |
+    And I should see the following twitters:
+      | twitter         |
+      | @aslak_hellesoy |
+      | @jbpros         |
+      | @mattwynne      |

--- a/tests/feature/test_datatable.py
+++ b/tests/feature/test_datatable.py
@@ -1,0 +1,36 @@
+"""Datatables feature tests."""
+
+from pytest_bdd import (
+    given,
+    scenario,
+    then,
+)
+
+
+@scenario("test_datatable.feature", "I use datatables")
+def test_i_use_datatables():
+    """I use datatables."""
+
+
+@given("the following users exist:")
+def the_following_users_exist(datatable):
+    """the following users exist:."""
+    return datatable[1]
+
+
+@then("I should see the following names:")
+def i_should_see(datatable, the_following_users_exist):
+    names = [row[0] for row in the_following_users_exist]
+    assert names == sum(datatable[1], [])
+
+
+@then("I should see the following emails:")
+def i_should_see(datatable, the_following_users_exist):
+    emails = [row[1] for row in the_following_users_exist]
+    assert emails == sum(datatable[1], [])
+
+
+@then("I should see the following twitters:")
+def i_should_see(datatable, the_following_users_exist):
+    twitters = [row[2] for row in the_following_users_exist]
+    assert twitters == sum(datatable[1], [])


### PR DESCRIPTION
Implement datatables for `Given` clauses. The work for this was mainly done in https://github.com/pytest-dev/pytest-bdd/pull/180. I am recreating it since I am taking it over to help get this merged in. The changes are identical between the two. All I did was merge in the latest changes to the PR/resolved merge conflicts and added more testing.

@youtux @olegpidsadnyi can we get this reviewed/merged in please? It looks like a lot of the community wants this feature ( myself included ) based off of the comments in the original PR.

Copied from origin PR: Fixes #150 and helps mitigating the effects of #157