### PR TITLE
Fix gherkin terminal report colouring

### DIFF
--- a/src/pytest_bdd/gherkin_terminal_reporter.py
+++ b/src/pytest_bdd/gherkin_terminal_reporter.py
@@ -93,7 +93,10 @@ class GherkinTerminalReporter(TerminalReporter):
                 self._tw.write(report.scenario["name"], **scenario_markup)
                 self._tw.write("\n")
                 for step in report.scenario["steps"]:
-                    self._tw.write(f"        {step['keyword']} {step['name']}\n", **scenario_markup)
+                    step_markup = (
+                        {"red": True} if step["failed"] else ({"yellow": True} if step["skipped"] else {"green": True})
+                    )
+                    self._tw.write(f"        {step['keyword']} {step['name']}\n", **step_markup)
                 self._tw.write("    " + word, **word_markup)
                 self._tw.write("\n\n")
             else:

--- a/src/pytest_bdd/hooks.py
+++ b/src/pytest_bdd/hooks.py
@@ -25,6 +25,10 @@ def pytest_bdd_after_step(request, feature, scenario, step, step_func, step_func
     """Called after step function is successfully executed."""
 
 
+def pytest_bdd_step_skip(request, feature, scenario, step, step_func, step_func_args, exception):
+    """Called when step function is skipped."""
+
+
 def pytest_bdd_step_error(request, feature, scenario, step, step_func, step_func_args, exception):
     """Called when step function failed to execute."""
 

--- a/src/pytest_bdd/parser.py
+++ b/src/pytest_bdd/parser.py
@@ -296,6 +296,7 @@ class Step:
     indent: int
     keyword: str
     failed: bool = field(init=False, default=False)
+    skipped: bool = field(init=False, default=False)
     scenario: ScenarioTemplate | None = field(init=False, default=None)
     background: Background | None = field(init=False, default=None)
     lines: list[str] = field(init=False, default_factory=list)
@@ -308,6 +309,7 @@ class Step:
         self.keyword = keyword
 
         self.failed = False
+        self.skipped = False
         self.scenario = None
         self.background = None
         self.lines = []

--- a/src/pytest_bdd/plugin.py
+++ b/src/pytest_bdd/plugin.py
@@ -88,6 +88,19 @@ def pytest_bdd_before_scenario(request: FixtureRequest, feature: Feature, scenar
 
 
 @pytest.hookimpl(tryfirst=True)
+def pytest_bdd_step_skip(
+    request: FixtureRequest,
+    feature: Feature,
+    scenario: Scenario,
+    step: Step,
+    step_func: Callable,
+    step_func_args: dict,
+    exception: Exception,
+) -> None:
+    reporting.step_skip(request, feature, scenario, step, step_func, step_func_args, exception)
+
+
+@pytest.hookimpl(tryfirst=True)
 def pytest_bdd_step_error(
     request: FixtureRequest,
     feature: Feature,

--- a/src/pytest_bdd/reporting.py
+++ b/src/pytest_bdd/reporting.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
 class StepReport:
     """Step execution report."""
 
+    skipped = False
     failed = False
     stopped = None
 
@@ -44,16 +45,20 @@ class StepReport:
             "type": self.step.type,
             "keyword": self.step.keyword,
             "line_number": self.step.line_number,
+            "skipped": self.skipped,
             "failed": self.failed,
             "duration": self.duration,
         }
 
-    def finalize(self, failed: bool) -> None:
+
+    def finalize(self, failed: bool, skipped=False) -> None:
         """Stop collecting information and finalize the report.
 
         :param bool failed: Whether the step execution is failed.
+        :param bool skipped: Indicates if the step execution is skipped.
         """
         self.stopped = time.perf_counter()
+        self.skipped = skipped
         self.failed = failed
 
     @property

--- a/src/pytest_bdd/reporting.py
+++ b/src/pytest_bdd/reporting.py
@@ -50,7 +50,6 @@ class StepReport:
             "duration": self.duration,
         }
 
-
     def finalize(self, failed: bool, skipped=False) -> None:
         """Stop collecting information and finalize the report.
 
@@ -177,6 +176,7 @@ def step_skip(
 ) -> None:
     """Finalize the step report as skipped."""
     request.node.__scenario_report__.skip()
+
 
 def step_error(
     request: FixtureRequest,

--- a/src/pytest_bdd/reporting.py
+++ b/src/pytest_bdd/reporting.py
@@ -138,6 +138,17 @@ class ScenarioReport:
             report.finalize(failed=True)
             self.add_step_report(report)
 
+    def skip(self):
+        """Stop collecting information and finalize the report as skipped."""
+        self.current_step_report.finalize(failed=False, skipped=True)
+        remaining_steps = self.scenario.steps[len(self.step_reports) :]
+
+        # Skip the rest of the steps and make reports.
+        for step in remaining_steps:
+            report = StepReport(step=step)
+            report.finalize(failed=False, skipped=True)
+            self.add_step_report(report)
+
 
 def runtest_makereport(item: Item, call: CallInfo, rep: TestReport) -> None:
     """Store item in the report object."""
@@ -154,6 +165,18 @@ def before_scenario(request: FixtureRequest, feature: Feature, scenario: Scenari
     """Create scenario report for the item."""
     request.node.__scenario_report__ = ScenarioReport(scenario=scenario)
 
+
+def step_skip(
+    request: FixtureRequest,
+    feature: Feature,
+    scenario: Scenario,
+    step: Step,
+    step_func: Callable,
+    step_func_args: dict,
+    exception: Exception,
+) -> None:
+    """Finalize the step report as skipped."""
+    request.node.__scenario_report__.skip()
 
 def step_error(
     request: FixtureRequest,

--- a/src/pytest_bdd/scenario.py
+++ b/src/pytest_bdd/scenario.py
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING, Callable, Iterator, cast
 import pytest
 from _pytest.fixtures import FixtureDef, FixtureManager, FixtureRequest, call_fixture_func
 from _pytest.nodes import iterparentnodeids
+from _pytest.outcomes import Skipped
 
 from . import exceptions
 from .feature import get_feature, get_features
@@ -159,6 +160,9 @@ def _execute_step_function(
         return_value = call_fixture_func(fixturefunc=context.step_func, request=request, kwargs=kwargs)
     except Exception as exception:
         request.config.hook.pytest_bdd_step_error(exception=exception, **kw)
+        raise
+    except Skipped as exception:
+        request.config.hook.pytest_bdd_step_skip(exception=exception, **kw)
         raise
 
     if context.target_fixture is not None:

--- a/tests/feature/test_report.py
+++ b/tests/feature/test_report.py
@@ -119,6 +119,7 @@ def test_step_trace(pytester):
                 "keyword": "Given",
                 "line_number": 6,
                 "name": "a passing step",
+                "skipped": False,
                 "type": "given",
             },
             {
@@ -127,6 +128,7 @@ def test_step_trace(pytester):
                 "keyword": "And",
                 "line_number": 7,
                 "name": "some other passing step",
+                "skipped": False,
                 "type": "given",
             },
         ],
@@ -154,6 +156,7 @@ def test_step_trace(pytester):
                 "keyword": "Given",
                 "line_number": 11,
                 "name": "a passing step",
+                "skipped": False,
                 "type": "given",
             },
             {
@@ -162,6 +165,7 @@ def test_step_trace(pytester):
                 "keyword": "And",
                 "line_number": 12,
                 "name": "a failing step",
+                "skipped": False,
                 "type": "given",
             },
         ],
@@ -188,6 +192,7 @@ def test_step_trace(pytester):
                 "keyword": "Given",
                 "line_number": 15,
                 "name": "there are 12 cucumbers",
+                "skipped": False,
                 "type": "given",
             },
             {
@@ -196,6 +201,7 @@ def test_step_trace(pytester):
                 "keyword": "When",
                 "line_number": 16,
                 "name": "I eat 5 cucumbers",
+                "skipped": False,
                 "type": "when",
             },
             {
@@ -204,6 +210,7 @@ def test_step_trace(pytester):
                 "keyword": "Then",
                 "line_number": 17,
                 "name": "I should have 7 cucumbers",
+                "skipped": False,
                 "type": "then",
             },
         ],
@@ -230,6 +237,7 @@ def test_step_trace(pytester):
                 "keyword": "Given",
                 "line_number": 15,
                 "name": "there are 5 cucumbers",
+                "skipped": False,
                 "type": "given",
             },
             {
@@ -238,6 +246,7 @@ def test_step_trace(pytester):
                 "keyword": "When",
                 "line_number": 16,
                 "name": "I eat 4 cucumbers",
+                "skipped": False,
                 "type": "when",
             },
             {
@@ -246,6 +255,7 @@ def test_step_trace(pytester):
                 "keyword": "Then",
                 "line_number": 17,
                 "name": "I should have 1 cucumbers",
+                "skipped": False,
                 "type": "then",
             },
         ],

--- a/tests/feature/test_report.py
+++ b/tests/feature/test_report.py
@@ -25,6 +25,7 @@ def test_step_trace(pytester):
         feature-tag
         scenario-passing-tag
         scenario-failing-tag
+        scenario-skipping-tag
     """
         ),
     )
@@ -33,7 +34,7 @@ def test_step_trace(pytester):
         test=textwrap.dedent(
             """
     @feature-tag
-    Feature: One passing scenario, one failing scenario
+    Feature: One passing scenario, one failing scenario, one skipping scenario
 
         @scenario-passing-tag
         Scenario: Passing
@@ -44,6 +45,12 @@ def test_step_trace(pytester):
         Scenario: Failing
             Given a passing step
             And a failing step
+
+        @scenario-skipping-tag
+        Scenario: Skipping
+            Given a passing step
+            And a skipping step
+            And a passing step
 
         Scenario Outline: Outlined
             Given there are <start> cucumbers
@@ -76,6 +83,10 @@ def test_step_trace(pytester):
         def _():
             raise Exception('Error')
 
+        @given('a skipping step')
+        def _():
+            pytest.skip()
+
         @given(parsers.parse('there are {start:d} cucumbers'), target_fixture="cucumbers")
         def _(start):
             assert isinstance(start, int)
@@ -106,7 +117,7 @@ def test_step_trace(pytester):
             "description": "",
             "filename": str(feature),
             "line_number": 2,
-            "name": "One passing scenario, one failing scenario",
+            "name": "One passing scenario, one failing scenario, one skipping scenario",
             "rel_filename": str(relpath),
             "tags": ["feature-tag"],
         },
@@ -143,7 +154,7 @@ def test_step_trace(pytester):
             "description": "",
             "filename": str(feature),
             "line_number": 2,
-            "name": "One passing scenario, one failing scenario",
+            "name": "One passing scenario, one failing scenario, one skipping scenario",
             "rel_filename": str(relpath),
             "tags": ["feature-tag"],
         },
@@ -173,24 +184,69 @@ def test_step_trace(pytester):
     }
     assert report == expected
 
+    report = result.matchreport("test_skipping", when="call").scenario
+    expected = {
+        "feature": {
+            "description": "",
+            "filename": str(feature),
+            "line_number": 2,
+            "name": "One passing scenario, one failing scenario, one skipping scenario",
+            "rel_filename": str(relpath),
+            "tags": ["feature-tag"],
+        },
+        "line_number": 15,
+        "name": "Skipping",
+        "steps": [
+            {
+                "duration": OfType(float),
+                "failed": False,
+                "keyword": "Given",
+                "line_number": 16,
+                "name": "a passing step",
+                "skipped": False,
+                "type": "given",
+            },
+            {
+                "duration": OfType(float),
+                "failed": False,
+                "keyword": "And",
+                "line_number": 17,
+                "name": "a skipping step",
+                "skipped": True,
+                "type": "given",
+            },
+            {
+                "duration": OfType(float),
+                "failed": False,
+                "keyword": "And",
+                "line_number": 18,
+                "name": "a passing step",
+                "skipped": True,
+                "type": "given",
+            },
+        ],
+        "tags": ["scenario-skipping-tag"],
+    }
+    assert report == expected
+
     report = result.matchreport("test_outlined[12-5-7]", when="call").scenario
     expected = {
         "feature": {
             "description": "",
             "filename": str(feature),
             "line_number": 2,
-            "name": "One passing scenario, one failing scenario",
+            "name": "One passing scenario, one failing scenario, one skipping scenario",
             "rel_filename": str(relpath),
             "tags": ["feature-tag"],
         },
-        "line_number": 14,
+        "line_number": 20,
         "name": "Outlined",
         "steps": [
             {
                 "duration": OfType(float),
                 "failed": False,
                 "keyword": "Given",
-                "line_number": 15,
+                "line_number": 21,
                 "name": "there are 12 cucumbers",
                 "skipped": False,
                 "type": "given",
@@ -199,7 +255,7 @@ def test_step_trace(pytester):
                 "duration": OfType(float),
                 "failed": False,
                 "keyword": "When",
-                "line_number": 16,
+                "line_number": 22,
                 "name": "I eat 5 cucumbers",
                 "skipped": False,
                 "type": "when",
@@ -208,7 +264,7 @@ def test_step_trace(pytester):
                 "duration": OfType(float),
                 "failed": False,
                 "keyword": "Then",
-                "line_number": 17,
+                "line_number": 23,
                 "name": "I should have 7 cucumbers",
                 "skipped": False,
                 "type": "then",
@@ -224,18 +280,18 @@ def test_step_trace(pytester):
             "description": "",
             "filename": str(feature),
             "line_number": 2,
-            "name": "One passing scenario, one failing scenario",
+            "name": "One passing scenario, one failing scenario, one skipping scenario",
             "rel_filename": str(relpath),
             "tags": ["feature-tag"],
         },
-        "line_number": 14,
+        "line_number": 20,
         "name": "Outlined",
         "steps": [
             {
                 "duration": OfType(float),
                 "failed": False,
                 "keyword": "Given",
-                "line_number": 15,
+                "line_number": 21,
                 "name": "there are 5 cucumbers",
                 "skipped": False,
                 "type": "given",
@@ -244,7 +300,7 @@ def test_step_trace(pytester):
                 "duration": OfType(float),
                 "failed": False,
                 "keyword": "When",
-                "line_number": 16,
+                "line_number": 22,
                 "name": "I eat 4 cucumbers",
                 "skipped": False,
                 "type": "when",
@@ -253,7 +309,7 @@ def test_step_trace(pytester):
                 "duration": OfType(float),
                 "failed": False,
                 "keyword": "Then",
-                "line_number": 17,
+                "line_number": 23,
                 "name": "I should have 1 cucumbers",
                 "skipped": False,
                 "type": "then",


### PR DESCRIPTION
Add a extra hook to mark steps as skipped, which will allow to distinguish if a step is skipped or not and therefor the output colouring could be done properly. 

This PR closes #214 #299 #248 