### PR TITLE
Allow Given, When and Then in feature description

### DIFF
--- a/pytest_bdd/__init__.py
+++ b/pytest_bdd/__init__.py
@@ -2,7 +2,8 @@
 
 from pytest_bdd.steps import given, when, then
 from pytest_bdd.scenario import scenario, scenarios
+from pytest_bdd.exceptions import FeatureWarning
 
 __version__ = "3.4.0"
 
-__all__ = [given.__name__, when.__name__, then.__name__, scenario.__name__, scenarios.__name__]
+__all__ = [given.__name__, when.__name__, then.__name__, scenario.__name__, scenarios.__name__, FeatureWarning.__name__]

--- a/pytest_bdd/exceptions.py
+++ b/pytest_bdd/exceptions.py
@@ -47,3 +47,6 @@ class FeatureError(Exception):
     def __str__(self):
         """String representation."""
         return self.message.format(*self.args)
+
+class FeatureWarning(UserWarning):
+    """Feature parse warning."""

--- a/pytest_bdd/exceptions.py
+++ b/pytest_bdd/exceptions.py
@@ -48,5 +48,6 @@ class FeatureError(Exception):
         """String representation."""
         return self.message.format(*self.args)
 
+
 class FeatureWarning(UserWarning):
     """Feature parse warning."""

--- a/pytest_bdd/feature.py
+++ b/pytest_bdd/feature.py
@@ -300,11 +300,12 @@ class Feature(object):
                 if not scenario and prev_mode not in allowed_prev_mode and mode in types.STEP_TYPES:
                     if prev_mode == types.FEATURE:
                         import warnings
+
                         warnings.warn(
                             "Step definition outside of a Scenario or a Background ({filename}:{line_number} {clean_line})".format(
                                 line_number=line_number, clean_line=clean_line, filename=prev_mode
                             ),
-                            exceptions.FeatureWarning
+                            exceptions.FeatureWarning,
                         )
                         mode = prev_mode
                     else:

--- a/pytest_bdd/feature.py
+++ b/pytest_bdd/feature.py
@@ -298,9 +298,19 @@ class Feature(object):
                 allowed_prev_mode = (types.BACKGROUND, types.GIVEN, types.WHEN)
 
                 if not scenario and prev_mode not in allowed_prev_mode and mode in types.STEP_TYPES:
-                    raise exceptions.FeatureError(
-                        "Step definition outside of a Scenario or a Background", line_number, clean_line, filename
-                    )
+                    if prev_mode == types.FEATURE:
+                        import warnings
+                        warnings.warn(
+                            "Step definition outside of a Scenario or a Background ({filename}:{line_number} {clean_line})".format(
+                                line_number=line_number, clean_line=clean_line, filename=prev_mode
+                            ),
+                            exceptions.FeatureWarning
+                        )
+                        mode = prev_mode
+                    else:
+                        raise exceptions.FeatureError(
+                            "Step definition outside of a Scenario or a Background", line_number, clean_line, filename
+                        )
 
                 if mode == types.FEATURE:
                     if prev_mode is None or prev_mode == types.TAG:

--- a/tests/feature/test_description.py
+++ b/tests/feature/test_description.py
@@ -14,6 +14,9 @@ def test_description(testdir):
             In order to achieve something
             I want something
             Because it will be cool
+            Given it is valid description
+            When it starts working
+            Then I will be happy
 
 
             Some description goes here.
@@ -45,6 +48,9 @@ def test_description(testdir):
                 In order to achieve something
                 I want something
                 Because it will be cool
+                Given it is valid description
+                When it starts working
+                Then I will be happy
 
 
                 Some description goes here.\"\"\"
@@ -53,5 +59,5 @@ def test_description(testdir):
         )
     )
 
-    result = testdir.runpytest()
+    result = testdir.runpytest("-W ignore::pytest_bdd.FeatureWarning")
     result.assert_outcomes(passed=2)


### PR DESCRIPTION
Raise only warning for following feature:
```
        Feature: Description

            In order to achieve something
            I want something
            Because it will be cool
            Given it is valid description
            When it starts working
            Then I will be happy


            Some description goes here.

            Scenario: Description
                Given I have a bar
```