### PR TITLE
Fix bug when using comments in the "Examples:" section

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+4.0.2
+-----
+- Fix a bug that prevents using comments in the ``Examples:`` section. (youtux)
+
+
 4.0.1
 -----
 - Fixed performance regression introduced in 4.0.0 where collection time of tests would take way longer than before. (youtux)

--- a/pytest_bdd/__init__.py
+++ b/pytest_bdd/__init__.py
@@ -3,6 +3,6 @@
 from pytest_bdd.steps import given, when, then
 from pytest_bdd.scenario import scenario, scenarios
 
-__version__ = "4.0.1"
+__version__ = "4.0.2"
 
 __all__ = [given.__name__, when.__name__, then.__name__, scenario.__name__, scenarios.__name__]

--- a/pytest_bdd/feature.py
+++ b/pytest_bdd/feature.py
@@ -150,7 +150,7 @@ def split_line(line):
 
     :return: List of strings.
     """
-    return [cell.replace("\\|", "|").strip() for cell in SPLIT_LINE_RE.split(line[1:-1])]
+    return [cell.replace("\\|", "|").strip() for cell in SPLIT_LINE_RE.split(line)[1:-1]]
 
 
 def get_features(paths, **kwargs):

--- a/pytest_bdd/parser.py
+++ b/pytest_bdd/parser.py
@@ -34,7 +34,7 @@ def split_line(line):
 
     :return: List of strings.
     """
-    return [cell.replace("\\|", "|").strip() for cell in SPLIT_LINE_RE.split(line[1:-1])]
+    return [cell.replace("\\|", "|").strip() for cell in SPLIT_LINE_RE.split(line)[1:-1]]
 
 
 def parse_line(line):

--- a/tests/feature/test_outline.py
+++ b/tests/feature/test_outline.py
@@ -42,7 +42,7 @@ def test_outlined(testdir):
 
                     Examples:
                     | start | eat | left |
-                    |  12   |  5  |  7   |
+                    |  12   |  5  |  7   | # a comment
                     |  5    |  4  |  1   |
 
             """


### PR DESCRIPTION
The following feature can't be parsed correctly:
```
            Feature: Outline
                Scenario Outline: Outlined given, when, thens
                    Given there are <start> cucumbers
                    When I eat <eat> cucumbers
                    Then I should have <left> cucumbers

                    Examples:
                    | start | eat | left |
                    |  12   |  5  |  7   | # a comment
                    |  5    |  4  |  1   |
```

This is the error:
```
============================= test session starts ==============================
platform darwin -- Python 3.6.12, pytest-6.1.2, py-1.9.0, pluggy-0.13.1
rootdir: /private/var/folders/sq/31n5n56x4j7d6q9srl_t7w_80000gn/T/pytest-of-youtux/pytest-28/test_outlined0
plugins: bdd-4.0.1
collected 0 items / 1 error

==================================== ERRORS ====================================
______________________ ERROR collecting test_outlined.py _______________________
test_outlined.py::test_outline: in "parametrize" the number of names (3):
  ['start', 'eat', 'left']
must be equal to the number of values (4):
  [12, 5.0, '7', '# a commen']
=========================== short test summary info ============================
ERROR test_outlined.py
!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!
=============================== 1 error in 0.07s ===============================
```

It seems the issue was introduced in https://github.com/pytest-dev/pytest-bdd/commit/36bd74b0405788ead8fbf1615a2dfd7564db1a16#diff-b75d8d89bc971feaa0346a1f1e846a4751b49939ec93ca8f4f5c3be627c94245R152.
This PR will fix it.