### PR TITLE
Drop the pytest dot

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ develop: .env
 	.env/bin/pip install -e . -r requirements-testing.txt tox python-coveralls
 
 coverage: develop
-	coverage run --source=pytest_bdd .env/bin/py.test tests
+	coverage run --source=pytest_bdd .env/bin/pytest tests
 	coverage report -m
 
 test: develop

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
-BDD library for the py.test runner
-==================================
+BDD library for the pytest runner
+=================================
 
 .. image:: http://img.shields.io/pypi/v/pytest-bdd.svg
    :target: https://pypi.python.org/pypi/pytest-bdd
@@ -730,7 +730,7 @@ scenario test, so we can use standard test selection:
 
 .. code-block:: bash
 
-    py.test -m "backend and login and successful"
+    pytest -m "backend and login and successful"
 
 The feature and scenario markers are not different from standard pytest markers, and the `@` symbol is stripped out
 automatically to allow test selector expressions. If you want to have bdd-related tags to be distinguishable from the
@@ -739,7 +739,7 @@ Note that if you use pytest `--strict` option, all bdd tags mentioned in the fea
 `markers` setting of the `pytest.ini` config. Also for tags please use names which are python-compartible variable
 names, eg starts with a non-number, underscore alphanumberic, etc. That way you can safely use tags for tests filtering.
 
-You can customize how hooks are converted to pytest marks by implementing the
+You can customize how tags are converted to pytest marks by implementing the
 ``pytest_bdd_apply_tag`` hook and returning ``True`` from it:
 
 .. code-block:: python
@@ -1084,27 +1084,27 @@ To have an output in json format:
 
 ::
 
-    py.test --cucumberjson=<path to json report>
+    pytest --cucumberjson=<path to json report>
 
 This will output an expanded (meaning scenario outlines will be expanded to several scenarios) cucumber format.
 To also fill in parameters in the step name, you have to explicitly tell pytest-bdd to use the expanded format:
 
 ::
 
-    py.test --cucumberjson=<path to json report> --cucumberjson-expanded
+    pytest --cucumberjson=<path to json report> --cucumberjson-expanded
 
 To enable gherkin-formatted output on terminal, use
 
 ::
 
-    py.test --gherkin-terminal-reporter
+    pytest --gherkin-terminal-reporter
 
 
 Terminal reporter supports expanded format as well
 
 ::
 
-    py.test --gherkin-terminal-reporter-expanded
+    pytest --gherkin-terminal-reporter-expanded
 
 
 
@@ -1136,7 +1136,7 @@ test execution. The code suggestion tool is called via passing additional pytest
 
 ::
 
-    py.test --generate-missing --feature features tests/functional
+    pytest --generate-missing --feature features tests/functional
 
 The output will be like:
 

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
     + [("Programming Language :: Python :: %s" % x) for x in "3.6 3.7 3.8 3.9".split()],
     python_requires=">=3.6",
     install_requires=["glob2", "Mako", "parse", "parse_type", "py", "pytest>=4.3"],
-    # the following makes a plugin available to py.test
+    # the following makes a plugin available to pytest
     entry_points={
         "pytest11": ["pytest-bdd = pytest_bdd.plugin"],
         "console_scripts": ["pytest-bdd = pytest_bdd.scripts:main"],


### PR DESCRIPTION
`pytest` has been the recommended spelling (rather than `py.test` ever [since pytest 3.0.0 (2016)](https://docs.pytest.org/en/stable/changelog.html#id1309), and pytest has been dropping the dot in its docs even before that.