### PR TITLE
Support `target_fixture` in `when` and `then` steps.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,7 @@ Changelog
 
 Unreleased
 -----------
+- `when` and `then` steps now can provide a `target_fixture`, just like `given` does. Discussion at https://github.com/pytest-dev/pytest-bdd/issues/402.
 - Drop compatibility for python 2 and officially support only python >= 3.6.
 - Fix error when using `--cucumber-json-expanded` in combination with `example_converters` (marcbrossaissogeti).
 - Fix `--generate-missing` not correctly recognizing steps with parsers

--- a/README.rst
+++ b/README.rst
@@ -368,20 +368,24 @@ A common use case is when we have to assert the outcome of an HTTP request:
 
     from pytest_bdd import scenarios, given, when, then
 
+    from my_app.models import Article
+
     scenarios("blog.feature")
+
 
     @given("there is an article", target_fixture="article")
     def there_is_an_article():
         return Article()
 
+
     @when("I request the deletion of the article", target_fixture="request_result")
-    def there_should_be_a_new_article(article, http_client):  # <-- Important bit here
+    def there_should_be_a_new_article(article, http_client):
         return http_client.delete(f"/articles/{article.uid}")
+
 
     @then("the request should be successful")
     def article_is_published(request_result):
-        assert request_result.status_code = 200
-
+        assert request_result.status_code == 200
 
 
 .. code-block:: gherkin

--- a/README.rst
+++ b/README.rst
@@ -359,6 +359,43 @@ it will stay untouched. To allow this, special parameter `target_fixture` exists
 In this example existing fixture `foo` will be overridden by given step `I have injecting given` only for scenario it's
 used in.
 
+Sometimes it is also useful to let `when` and `then` steps to provide a fixture as well.
+A common use case is when we have to assert the outcome of an HTTP request:
+
+.. code-block:: python
+
+    # test_blog.py
+
+    from pytest_bdd import scenarios, given, when, then
+
+    scenarios("blog.feature")
+
+    @given("there is an article", target_fixture="article")
+    def there_is_an_article():
+        return Article()
+
+    @when("I request the deletion of the article", target_fixture="request_result")
+    def there_should_be_a_new_article(article, http_client):  # <-- Important bit here
+        return http_client.delete(f"/articles/{article.uid}")
+
+    @then("the request should be successful")
+    def article_is_published(request_result):
+        assert request_result.status_code = 200
+
+
+
+.. code-block:: gherkin
+
+    # blog.feature
+
+    Feature: Blog
+        Scenario: Deleting the article
+            Given there is an article
+
+            When I request the deletion of the article
+
+            Then the request should be successful
+
 
 Multiline steps
 ---------------

--- a/pytest_bdd/steps.py
+++ b/pytest_bdd/steps.py
@@ -61,35 +61,37 @@ def given(name, converters=None, target_fixture=None):
     :param name: Step name or a parser object.
     :param converters: Optional `dict` of the argument or parameter converters in form
                        {<param_name>: <converter function>}.
-    :param target_fixture: Target fixture name to replace by steps definition function
+    :param target_fixture: Target fixture name to replace by steps definition function.
 
     :return: Decorator function for the step.
     """
     return _step_decorator(GIVEN, name, converters=converters, target_fixture=target_fixture)
 
 
-def when(name, converters=None):
+def when(name, converters=None, target_fixture=None):
     """When step decorator.
 
     :param name: Step name or a parser object.
     :param converters: Optional `dict` of the argument or parameter converters in form
                        {<param_name>: <converter function>}.
+    :param target_fixture: Target fixture name to replace by steps definition function.
 
     :return: Decorator function for the step.
     """
-    return _step_decorator(WHEN, name, converters=converters)
+    return _step_decorator(WHEN, name, converters=converters, target_fixture=target_fixture)
 
 
-def then(name, converters=None):
+def then(name, converters=None, target_fixture=None):
     """Then step decorator.
 
     :param name: Step name or a parser object.
     :param converters: Optional `dict` of the argument or parameter converters in form
                        {<param_name>: <converter function>}.
+    :param target_fixture: Target fixture name to replace by steps definition function.
 
     :return: Decorator function for the step.
     """
-    return _step_decorator(THEN, name, converters=converters)
+    return _step_decorator(THEN, name, converters=converters, target_fixture=target_fixture)
 
 
 def _step_decorator(step_type, step_name, converters=None, target_fixture=None):


### PR DESCRIPTION
As discussed in https://github.com/pytest-dev/pytest-bdd/issues/402, we want to allow `when` and `then` steps to provide a target fixture.

Fixes #402, closes #405 and #419.