### PR TITLE
Default parser switched to cfparse

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+Unreleased
+----------
+
+- Default parser is switched to cfparse. Step name is compiled to cfparse
+- Step functions could get compiled instances of parse, cfparse and re.compile directly
+
 5.0.0
 -----
 This release introduces breaking changes, please refer to the :ref:`Migration from 4.x.x`.

--- a/README.rst
+++ b/README.rst
@@ -215,6 +215,19 @@ for `cfparse` parser
     def start_cucumbers(start):
         return dict(start=start, eat=0)
 
+or the same:
+.. code-block:: python
+
+    from parse_type.cfparse import Parser as cfparse
+
+    @given(
+        cfparse("there are {start:Number} cucumbers",
+        extra_types=dict(Number=int)),
+        target_fixture="start_cucumbers",
+    )
+    def start_cucumbers(start):
+        return dict(start=start, eat=0)
+
 for `re` parser
 
 .. code-block:: python
@@ -229,6 +242,18 @@ for `re` parser
     def start_cucumbers(start):
         return dict(start=start, eat=0)
 
+or the same:
+
+.. code-block:: python
+    from re import compile as parse_re
+
+    @given(
+        parse_re(r"there are (?P<start>\d+) cucumbers"),
+        converters=dict(start=int),
+        target_fixture="start_cucumbers",
+    )
+    def start_cucumbers(start):
+        return dict(start=start, eat=0)
 
 Example:
 
@@ -249,7 +274,8 @@ The code will look like:
 .. code-block:: python
 
     import re
-    from pytest_bdd import scenario, given, when, then, parsers
+    from parse import Parser as parse
+    from pytest_bdd import scenario, given, when, then
 
 
     @scenario("arguments.feature", "Arguments for given, when, then")
@@ -257,17 +283,17 @@ The code will look like:
         pass
 
 
-    @given(parsers.parse("there are {start:d} cucumbers"), target_fixture="start_cucumbers")
+    @given(parse("there are {start:d} cucumbers"), target_fixture="start_cucumbers")
     def start_cucumbers(start):
         return dict(start=start, eat=0)
 
 
-    @when(parsers.parse("I eat {eat:d} cucumbers"))
+    @when(parse("I eat {eat:d} cucumbers"))
     def eat_cucumbers(start_cucumbers, eat):
         start_cucumbers["eat"] += eat
 
 
-    @then(parsers.parse("I should have {left:d} cucumbers"))
+    @then(parse("I should have {left:d} cucumbers"))
     def should_have_left_cucumbers(start_cucumbers, start, left):
         assert start_cucumbers['start'] == start
         assert start - start_cucumbers['eat'] == left

--- a/README.rst
+++ b/README.rst
@@ -637,6 +637,33 @@ This is allowed as long as parameter names do not clash:
             | carrots    |
             | tomatoes   |
 
+To not repeat steps as in example above you could want store your data in sequent Examples sections:
+
+
+.. code-block:: gherkin
+
+    Feature: Outline
+
+        Examples:
+        | start | eat | left |
+        |  12   |  5  |  7   |
+        |  5    |  4  |  1   |
+
+        Scenario Outline: Eat food
+            Given there are <start> <food>
+            When I eat <eat> <food>
+            Then I should have <left> <food>
+
+            Examples: Fruits
+            | food    |
+            | oranges |
+            | apples  |
+
+            Examples: Vegetables
+            | food       |
+            | carrots    |
+            | tomatoes   |
+
 
 Organizing your scenarios
 -------------------------

--- a/pytest_bdd/parsers.py
+++ b/pytest_bdd/parsers.py
@@ -3,44 +3,61 @@
 
 import re as base_re
 import sys
-from functools import partial
+from abc import ABCMeta, abstractmethod
+from typing import Any, Dict, Union
 
 import parse as base_parse
 from parse_type import cfparse as base_cfparse
 
+if sys.version_info >= (3, 8):
+    from typing import Protocol, runtime_checkable
+else:
+    try:
+        from typing_extensions import Protocol, runtime_checkable
+    except ImportError:
+        Protocol, runtime_checkable = object, lambda cls: cls
+
 _Re_Pattern = base_re.Pattern if sys.version_info >= (3, 7) else type(base_re.compile(""))
 
 
-class StepParser:
+@runtime_checkable
+class StepParserProtocol(Protocol):
+    name: Any
+
+    def parse_arguments(self, name) -> Dict[str, Any]:
+        ...
+
+    def is_matching(self, name) -> Union[bool, Any]:
+        ...
+
+
+class StepParser(StepParserProtocol, metaclass=ABCMeta):
     """Parser of the individual step."""
 
     def __init__(self, name):
         self.name = name
 
+    @abstractmethod
     def parse_arguments(self, name):
         """Get step arguments from the given step name.
 
         :return: `dict` of step arguments
         """
-        raise NotImplementedError()  # pragma: no cover
+        raise NotImplemented  # pragma: no cover
 
+    @abstractmethod
     def is_matching(self, name):
         """Match given name with the step name."""
-        raise NotImplementedError()  # pragma: no cover
+        raise NotImplemented  # pragma: no cover
 
 
 class _CommonRe(StepParser):
     regex: _Re_Pattern
 
     def parse_arguments(self, name):
-        """Get step arguments.
-
-        :return: `dict` of step arguments
-        """
         return self.regex.match(name).groupdict()
 
     def is_matching(self, name):
-        """Match given name with the step name."""
         return bool(self.regex.match(name))
 
 
@@ -64,14 +81,9 @@ class _CommonParse(StepParser):
     parser: base_parse.Parser
 
     def parse_arguments(self, name):
-        """Get step arguments.
-
-        :return: `dict` of step arguments
-        """
         return self.parser.parse(name).named
 
     def is_matching(self, name):
-        """Match given name with the step name."""
         try:
             return bool(self.parser.parse(name))
         except ValueError:
@@ -97,8 +109,10 @@ class cfparse(_CommonParse):
     """cfparse step parser."""
 
     def __init__(self, name, *args, **kwargs):
-        """Compile parse expression."""
+        """Stringify"""
+        name = str(name, **({"encoding": "utf-8"} if isinstance(name, bytes) else {}))
         super().__init__(name)
+        """Compile parse expression."""
         self.parser = base_cfparse.Parser(self.name, *args, **kwargs)
 
 
@@ -122,7 +136,7 @@ class string(StepParser):
         return self.name == name
 
 
-def get_parser(step_name):
+def get_parser(step_name: Union[str, StepParser, StepParserProtocol]) -> Union[StepParser, StepParserProtocol]:
     """Get parser by given name.
 
     :param step_name: name of the step to parse
@@ -131,14 +145,11 @@ def get_parser(step_name):
     :rtype: StepArgumentParser
     """
 
-    def does_support_parser_interface(obj):
-        return all(map(partial(hasattr, obj), ["is_matching", "parse_arguments"]))
-
-    if does_support_parser_interface(step_name):
+    if isinstance(step_name, StepParserProtocol):
         return step_name
     elif isinstance(step_name, _Re_Pattern):
         return _re(step_name)
     elif isinstance(step_name, base_parse.Parser):
         return _parse(step_name)
     else:
-        return string(step_name)
+        return cfparse(step_name)

--- a/pytest_bdd/utils.py
+++ b/pytest_bdd/utils.py
@@ -6,6 +6,8 @@ import typing
 from inspect import getframeinfo, signature
 from sys import _getframe
 
+from attr import Factory, attrib, attrs
+
 if typing.TYPE_CHECKING:
     from _pytest.pytester import RunResult
 
@@ -64,3 +66,17 @@ def collect_dumped_objects(result: "RunResult"):
     stdout = result.stdout.str()  # pytest < 6.2, otherwise we could just do str(result.stdout)
     payloads = re.findall(rf"{_DUMP_START}(.*?){_DUMP_END}", stdout)
     return [pickle.loads(base64.b64decode(payload)) for payload in payloads]
+
+
+@attrs
+class SimpleMapping(typing.Mapping):
+    _dict = attrib(default=Factory(dict), kw_only=True)
+
+    def __getitem__(self, item):
+        return self._dict[item]
+
+    def __iter__(self):
+        return iter(self._dict)
+
+    def __len__(self):
+        return len(self._dict)

--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -1,1 +1,2 @@
+execnet
 packaging

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,6 +41,10 @@ tests_require = tox
 packages = pytest_bdd
 include_package_data = True
 
+[options.extras_require]
+full =
+    typing-extensions
+
 [options.entry_points]
 pytest11 =
     pytest-bdd = pytest_bdd.plugin

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,9 @@ classifiers =
 [options]
 python_requires = >=3.6
 install_requires =
+    ;Already used in pytest
+    attrs
+
     glob2
     Mako
     parse

--- a/tests/args/cfparse/test_args.py
+++ b/tests/args/cfparse/test_args.py
@@ -2,8 +2,17 @@
 
 import textwrap
 
+from pytest import mark
 
-def test_every_step_takes_param_with_the_same_name(testdir):
+
+@mark.parametrize(
+    "parser_import_string",
+    [
+        "from pytest_bdd.parsers import cfparse",  # Deprecated
+        "from parse_type.cfparse import Parser as cfparse",
+    ],
+)
+def test_every_step_takes_param_with_the_same_name(testdir, parser_import_string):
     """Test every step takes param with the same name."""
     testdir.makefile(
         ".feature",
@@ -25,8 +34,10 @@ def test_every_step_takes_param_with_the_same_name(testdir):
         textwrap.dedent(
             """\
         import pytest
-        from pytest_bdd import parsers, given, when, then, scenario
-
+        from pytest_bdd import given, when, then, scenario
+        """
+            f"{parser_import_string}"
+            """
         @scenario("arguments.feature", "Every step takes a parameter with the same name")
         def test_arguments():
             pass
@@ -36,17 +47,17 @@ def test_every_step_takes_param_with_the_same_name(testdir):
             return [1, 2, 1, 0, 999999]
 
 
-        @given(parsers.cfparse("I have {euro:d} Euro"))
+        @given(cfparse("I have {euro:d} Euro"))
         def i_have(euro, values):
             assert euro == values.pop(0)
 
 
-        @when(parsers.cfparse("I pay {euro:d} Euro"))
+        @when(cfparse("I pay {euro:d} Euro"))
         def i_pay(euro, values, request):
             assert euro == values.pop(0)
 
 
-        @then(parsers.cfparse("I should have {euro:d} Euro"))
+        @then(cfparse("I should have {euro:d} Euro"))
         def i_should_have(euro, values):
             assert euro == values.pop(0)
 
@@ -57,7 +68,14 @@ def test_every_step_takes_param_with_the_same_name(testdir):
     result.assert_outcomes(passed=1)
 
 
-def test_argument_in_when(testdir):
+@mark.parametrize(
+    "parser_import_string",
+    [
+        "from pytest_bdd.parsers import cfparse",  # Deprecated
+        "from parse_type.cfparse import Parser as cfparse",
+    ],
+)
+def test_argument_in_when(testdir, parser_import_string):
     """Test step arguments in when steps."""
     testdir.makefile(
         ".feature",
@@ -76,8 +94,10 @@ def test_argument_in_when(testdir):
         textwrap.dedent(
             """\
         import pytest
-        from pytest_bdd import parsers, given, when, then, scenario
-
+        from pytest_bdd import given, when, then, scenario
+        """
+            f"{parser_import_string}"
+            """
         @scenario("arguments.feature", "Argument in when")
         def test_arguments():
             pass
@@ -88,17 +108,17 @@ def test_argument_in_when(testdir):
             return dict()
 
 
-        @given(parsers.cfparse("I have an argument {arg:Number}", extra_types=dict(Number=int)))
+        @given(cfparse("I have an argument {arg:Number}", extra_types=dict(Number=int)))
         def argument(arguments, arg):
             arguments["arg"] = arg
 
 
-        @when(parsers.cfparse("I get argument {arg:d}"))
+        @when(cfparse("I get argument {arg:d}"))
         def get_argument(arguments, arg):
             arguments["arg"] = arg
 
 
-        @then(parsers.cfparse("My argument should be {arg:d}"))
+        @then(cfparse("My argument should be {arg:d}"))
         def assert_that_my_argument_is_arg(arguments, arg):
             assert arguments["arg"] == arg
 

--- a/tests/args/parse/test_args.py
+++ b/tests/args/parse/test_args.py
@@ -1,9 +1,17 @@
 """Step arguments tests."""
 
 import textwrap
+from pytest import mark
 
 
-def test_every_steps_takes_param_with_the_same_name(testdir):
+@mark.parametrize(
+    "parser_import_string",
+    [
+        "from pytest_bdd.parsers import parse",
+        "from parse import Parser as parse",
+    ],
+)
+def test_every_steps_takes_param_with_the_same_name(testdir, parser_import_string):
     testdir.makefile(
         ".feature",
         arguments=textwrap.dedent(
@@ -24,8 +32,10 @@ def test_every_steps_takes_param_with_the_same_name(testdir):
         textwrap.dedent(
             """\
         import pytest
-        from pytest_bdd import parsers, given, when, then, scenario
-
+        from pytest_bdd import given, when, then, scenario
+        """
+            f"{parser_import_string}"
+            """
         @scenario("arguments.feature", "Every step takes a parameter with the same name")
         def test_arguments():
             pass
@@ -35,17 +45,17 @@ def test_every_steps_takes_param_with_the_same_name(testdir):
             return [1, 2, 1, 0, 999999]
 
 
-        @given(parsers.parse("I have {euro:d} Euro"))
+        @given(parse("I have {euro:d} Euro"))
         def i_have(euro, values):
             assert euro == values.pop(0)
 
 
-        @when(parsers.parse("I pay {euro:d} Euro"))
+        @when(parse("I pay {euro:d} Euro"))
         def i_pay(euro, values, request):
             assert euro == values.pop(0)
 
 
-        @then(parsers.parse("I should have {euro:d} Euro"))
+        @then(parse("I should have {euro:d} Euro"))
         def i_should_have(euro, values):
             assert euro == values.pop(0)
 
@@ -56,7 +66,14 @@ def test_every_steps_takes_param_with_the_same_name(testdir):
     result.assert_outcomes(passed=1)
 
 
-def test_argument_in_when_step_1(testdir):
+@mark.parametrize(
+    "parser_import_string",
+    [
+        "from pytest_bdd.parsers import parse",
+        "from parse import Parser as parse",
+    ],
+)
+def test_argument_in_when_step_1(testdir, parser_import_string):
     testdir.makefile(
         ".feature",
         arguments=textwrap.dedent(
@@ -74,7 +91,10 @@ def test_argument_in_when_step_1(testdir):
         textwrap.dedent(
             """\
         import pytest
-        from pytest_bdd import parsers, given, when, then, scenario
+        from pytest_bdd import given, when, then, scenario
+        """
+            f"{parser_import_string}"
+            """
 
         @pytest.fixture
         def arguments():
@@ -86,17 +106,17 @@ def test_argument_in_when_step_1(testdir):
             pass
 
 
-        @given(parsers.parse("I have an argument {arg:Number}", extra_types=dict(Number=int)))
+        @given(parse("I have an argument {arg:Number}", extra_types=dict(Number=int)))
         def argument(arguments, arg):
             arguments["arg"] = arg
 
 
-        @when(parsers.parse("I get argument {arg:d}"))
+        @when(parse("I get argument {arg:d}"))
         def get_argument(arguments, arg):
             arguments["arg"] = arg
 
 
-        @then(parsers.parse("My argument should be {arg:d}"))
+        @then(parse("My argument should be {arg:d}"))
         def assert_that_my_argument_is_arg(arguments, arg):
             assert arguments["arg"] == arg
 

--- a/tests/args/parse/test_args.py
+++ b/tests/args/parse/test_args.py
@@ -1,6 +1,7 @@
 """Step arguments tests."""
 
 import textwrap
+
 from pytest import mark
 
 

--- a/tests/args/regex/test_args.py
+++ b/tests/args/regex/test_args.py
@@ -1,9 +1,17 @@
 """Step arguments tests."""
 
 import textwrap
+from pytest import mark
 
 
-def test_every_steps_takes_param_with_the_same_name(testdir):
+@mark.parametrize(
+    "parser_import_string",
+    [
+        "from pytest_bdd.parsers import re as parse_re",
+        "from re import compile as parse_re",
+    ],
+)
+def test_every_steps_takes_param_with_the_same_name(testdir, parser_import_string):
     testdir.makefile(
         ".feature",
         arguments=textwrap.dedent(
@@ -22,9 +30,12 @@ def test_every_steps_takes_param_with_the_same_name(testdir):
 
     testdir.makepyfile(
         textwrap.dedent(
-            r"""
+            """\
         import pytest
-        from pytest_bdd import parsers, given, when, then, scenario
+        from pytest_bdd import given, when, then, scenario
+        """
+            f"{parser_import_string}"
+            r"""
 
         @scenario("arguments.feature", "Every step takes a parameter with the same name")
         def test_arguments():
@@ -34,17 +45,17 @@ def test_every_steps_takes_param_with_the_same_name(testdir):
         def values():
             return [1, 2, 1, 0, 999999]
 
-        @given(parsers.re(r"I have (?P<euro>\d+) Euro"), converters=dict(euro=int))
+        @given(parse_re(r"I have (?P<euro>\d+) Euro"), converters=dict(euro=int))
         def i_have(euro, values):
             assert euro == values.pop(0)
 
 
-        @when(parsers.re(r"I pay (?P<euro>\d+) Euro"), converters=dict(euro=int))
+        @when(parse_re(r"I pay (?P<euro>\d+) Euro"), converters=dict(euro=int))
         def i_pay(euro, values, request):
             assert euro == values.pop(0)
 
 
-        @then(parsers.re(r"I should have (?P<euro>\d+) Euro"), converters=dict(euro=int))
+        @then(parse_re(r"I should have (?P<euro>\d+) Euro"), converters=dict(euro=int))
         def i_should_have(euro, values):
             assert euro == values.pop(0)
 
@@ -55,7 +66,14 @@ def test_every_steps_takes_param_with_the_same_name(testdir):
     result.assert_outcomes(passed=1)
 
 
-def test_argument_in_when(testdir):
+@mark.parametrize(
+    "parser_import_string",
+    [
+        "from pytest_bdd.parsers import re as parse_re",
+        "from re import compile as parse_re",
+    ],
+)
+def test_argument_in_when(testdir, parser_import_string):
     testdir.makefile(
         ".feature",
         arguments=textwrap.dedent(
@@ -71,10 +89,12 @@ def test_argument_in_when(testdir):
 
     testdir.makepyfile(
         textwrap.dedent(
-            r"""
+            """\
         import pytest
-        from pytest_bdd import parsers, given, when, then, scenario
-
+        from pytest_bdd import given, when, then, scenario
+        """
+            f"{parser_import_string}"
+            r"""
 
         @pytest.fixture
         def arguments():
@@ -85,17 +105,17 @@ def test_argument_in_when(testdir):
         def test_arguments():
             pass
 
-        @given(parsers.re(r"I have an argument (?P<arg>\d+)"))
+        @given(parse_re(r"I have an argument (?P<arg>\d+)"))
         def argument(arguments, arg):
             arguments["arg"] = arg
 
 
-        @when(parsers.re(r"I get argument (?P<arg>\d+)"))
+        @when(parse_re(r"I get argument (?P<arg>\d+)"))
         def get_argument(arguments, arg):
             arguments["arg"] = arg
 
 
-        @then(parsers.re(r"My argument should be (?P<arg>\d+)"))
+        @then(parse_re(r"My argument should be (?P<arg>\d+)"))
         def assert_that_my_argument_is_arg(arguments, arg):
             assert arguments["arg"] == arg
 

--- a/tests/args/regex/test_args.py
+++ b/tests/args/regex/test_args.py
@@ -1,6 +1,7 @@
 """Step arguments tests."""
 
 import textwrap
+
 from pytest import mark
 
 

--- a/tests/feature/test_cucumber_json.py
+++ b/tests/feature/test_cucumber_json.py
@@ -176,7 +176,12 @@ def test_step_trace(testdir):
                     ],
                     "line": 15,
                     "type": "scenario",
-                    "id": "test_passing_outline[str-hello]",
+                    "id": (
+                        "test_passing_outline"
+                        "[[Scenario:Passing outline:line_no:15]>"
+                        "[Examples:example1:line_no:18]>"
+                        "[Row:0]:str-hello]"
+                    ),
                     "name": "Passing outline",
                 },
                 {
@@ -194,7 +199,12 @@ def test_step_trace(testdir):
                     ],
                     "line": 15,
                     "type": "scenario",
-                    "id": "test_passing_outline[int-42]",
+                    "id": (
+                        "test_passing_outline"
+                        "[[Scenario:Passing outline:line_no:15]>"
+                        "[Examples:example1:line_no:18]>"
+                        "[Row:1]:int-42]"
+                    ),
                     "name": "Passing outline",
                 },
                 {
@@ -212,7 +222,12 @@ def test_step_trace(testdir):
                     ],
                     "line": 15,
                     "type": "scenario",
-                    "id": "test_passing_outline[float-1.0]",
+                    "id": (
+                        "test_passing_outline"
+                        "[[Scenario:Passing outline:line_no:15]>"
+                        "[Examples:example1:line_no:18]>"
+                        "[Row:2]:float-1.0]"
+                    ),
                     "name": "Passing outline",
                 },
             ],

--- a/tests/feature/test_outline.py
+++ b/tests/feature/test_outline.py
@@ -167,6 +167,123 @@ def test_wrongly_outlined_extra_parameter(testdir):
     result.stdout.fnmatch_lines("*should match set of example values [[]'eat', 'left', 'start', 'unknown_param'[]].*")
 
 
+def test_wrongly_outlined_duplicated_parameter_scenario(testdir):
+    """Test parametrized scenario vertical example table has wrong format."""
+    testdir.makefile(
+        ".feature",
+        outline=textwrap.dedent(
+            """\
+            Feature: Outline
+                Scenario Outline: Outlined with wrong vertical example table
+                    Given there are <start> cucumbers
+                    When I eat <eat> cucumbers
+                    Then I should have <left> cucumbers
+
+                    Examples:
+                    | start | start | left |
+                    |   12  |   10  |   7  |
+                    |    2  |    1  |   1  |
+            """
+        ),
+    )
+    testdir.makeconftest(textwrap.dedent(STEPS))
+
+    testdir.makepyfile(
+        textwrap.dedent(
+            """\
+        from pytest_bdd import scenario
+
+        @scenario("outline.feature", "Outlined with wrong vertical example table")
+        def test_outline(request):
+            pass
+        """
+        )
+    )
+    result = testdir.runpytest()
+    assert_outcomes(result, errors=1)
+    result.stdout.fnmatch_lines(
+        "*Scenario has not valid examples. Example rows should contain unique parameters. "
+        '"start" appeared more than once.*'
+    )
+
+
+def test_wrongly_outlined_missing_parameter_scenario(testdir):
+    """Test parametrized scenario vertical example table has wrong format."""
+    testdir.makefile(
+        ".feature",
+        outline=textwrap.dedent(
+            """\
+            Feature: Outline
+                Scenario Outline: Outlined with wrong vertical example table
+                    Given there are <start> cucumbers
+                    When I eat <eat> cucumbers
+                    Then I should have <left> cucumbers
+
+                    Examples:
+                    | start | eat | left |
+                    |   12  | 10  |   7  |
+                    |    2  |  1  |
+            """
+        ),
+    )
+    testdir.makeconftest(textwrap.dedent(STEPS))
+
+    testdir.makepyfile(
+        textwrap.dedent(
+            """\
+        from pytest_bdd import scenario
+
+        @scenario("outline.feature", "Outlined with wrong vertical example table")
+        def test_outline(request):
+            pass
+        """
+        )
+    )
+    result = testdir.runpytest()
+    assert_outcomes(result, errors=1)
+    result.stdout.fnmatch_lines("*Scenario has not valid examples. All example rows must have same count of values.*")
+
+
+def test_wrongly_outlined_duplicated_parameter_feature(testdir):
+    """Test parametrized scenario vertical example table has wrong format."""
+    testdir.makefile(
+        ".feature",
+        outline=textwrap.dedent(
+            """\
+            Feature: Outline
+                Examples:
+                 | start | start | left |
+                 |   12  |   10  |   7  |
+                 |    2  |    1  |   1  |
+
+                Scenario Outline: Outlined with wrong vertical example table
+                    Given there are <start> cucumbers
+                    When I eat <eat> cucumbers
+                    Then I should have <left> cucumbers
+            """
+        ),
+    )
+    testdir.makeconftest(textwrap.dedent(STEPS))
+
+    testdir.makepyfile(
+        textwrap.dedent(
+            """\
+        from pytest_bdd import scenario
+
+        @scenario("outline.feature", "Outlined with wrong vertical example table")
+        def test_outline(request):
+            pass
+        """
+        )
+    )
+    result = testdir.runpytest()
+    assert_outcomes(result, errors=1)
+    result.stdout.fnmatch_lines(
+        "*Feature has not valid examples. Example rows should contain unique parameters. "
+        '"start" appeared more than once.*'
+    )
+
+
 def test_outlined_with_other_fixtures(testdir):
     """Test outlined scenario also using other parametrized fixture."""
     testdir.makefile(
@@ -353,6 +470,45 @@ def test_wrongly_outlined_duplicated_parameter_vertical_scenario(testdir):
     )
 
 
+def test_wrongly_outlined_missing_parameter_vertical_scenario(testdir):
+    """Test parametrized scenario vertical example table has wrong format."""
+    testdir.makefile(
+        ".feature",
+        outline=textwrap.dedent(
+            """\
+            Feature: Outline
+                Scenario Outline: Outlined with wrong vertical example table
+                    Given there are <start> cucumbers
+                    When I eat <eat> cucumbers
+                    Then I should have <left> cucumbers
+
+                    Examples: Vertical
+                    | start | 12 | 2 |
+                    | eat   | 10 | 1 |
+                    | left  | 7  |
+            """
+        ),
+    )
+    testdir.makeconftest(textwrap.dedent(STEPS))
+
+    testdir.makepyfile(
+        textwrap.dedent(
+            """\
+        from pytest_bdd import scenario
+
+        @scenario("outline.feature", "Outlined with wrong vertical example table")
+        def test_outline(request):
+            pass
+        """
+        )
+    )
+    result = testdir.runpytest()
+    assert_outcomes(result, errors=1)
+    result.stdout.fnmatch_lines(
+        "*Scenario has not valid examples. All example columns in Examples: Vertical must have same count of values.*"
+    )
+
+
 def test_wrongly_outlined_duplicated_parameter_vertical_feature(testdir):
     """Test parametrized feature vertical example table has wrong format."""
     testdir.makefile(
@@ -489,7 +645,6 @@ def test_outline_with_escaped_pipes(testdir):
     ]
 
 
-@pytest.mark.xfail(reason="https://github.com/pytest-dev/pytest-bdd/issues/479")
 def test_multi_outlined(testdir):
     testdir.makefile(
         ".feature",
@@ -540,7 +695,52 @@ def test_multi_outlined(testdir):
     # fmt: on
 
 
-@pytest.mark.xfail(reason="https://github.com/pytest-dev/pytest-bdd/issues/479")
+def test_multi_outlined_empty_examples(testdir):
+    testdir.makefile(
+        ".feature",
+        outline=textwrap.dedent(
+            """\
+            Feature: Outline
+
+                Examples:
+
+                Examples: Vertical
+
+                Examples:
+                |
+
+                Examples: Vertical
+                |
+
+                Scenario Outline: Outlined given, when, thens
+                    Given there are 12 apples
+                    When I eat 5 apples
+                    Then I should have 7 apples
+
+                    Examples:
+
+                    Examples: Vertical
+
+                    Examples:
+                    |
+
+                    Examples: Vertical
+                    |
+            """
+        ),
+    )
+
+    testdir.makepyfile(STEPS_OUTLINED)
+    result = testdir.runpytest("-s")
+    result.assert_outcomes(passed=1)
+    parametrizations = collect_dumped_objects(result)
+    # fmt: off
+    assert parametrizations == [
+        12, "apples", 5.0, "apples", "7", "apples",
+    ]
+    # fmt: on
+
+
 def test_multi_outlined_feature_with_parameter_union(testdir):
     testdir.makefile(
         ".feature",
@@ -584,7 +784,6 @@ def test_multi_outlined_feature_with_parameter_union(testdir):
     # fmt: on
 
 
-@pytest.mark.xfail(reason="https://github.com/pytest-dev/pytest-bdd/issues/479")
 def test_multi_outlined_scenario_and_feature_with_parameter_union(testdir):
     testdir.makefile(
         ".feature",

--- a/tests/feature/test_outline.py
+++ b/tests/feature/test_outline.py
@@ -122,87 +122,6 @@ def test_wrongly_outlined(testdir):
     result.stdout.fnmatch_lines("*should match set of example values [[]'eat', 'left', 'start', 'unknown_param'[]].*")
 
 
-def test_wrong_vertical_examples_scenario(testdir):
-    """Test parametrized scenario vertical example table has wrong format."""
-    testdir.makefile(
-        ".feature",
-        outline=textwrap.dedent(
-            """\
-            Feature: Outline
-                Scenario Outline: Outlined with wrong vertical example table
-                    Given there are <start> cucumbers
-                    When I eat <eat> cucumbers
-                    Then I should have <left> cucumbers
-
-                    Examples: Vertical
-                    | start | 12 | 2 |
-                    | start | 10 | 1 |
-                    | left  | 7  | 1 |
-            """
-        ),
-    )
-    testdir.makeconftest(textwrap.dedent(STEPS))
-
-    testdir.makepyfile(
-        textwrap.dedent(
-            """\
-        from pytest_bdd import scenario
-
-        @scenario("outline.feature", "Outlined with wrong vertical example table")
-        def test_outline(request):
-            pass
-        """
-        )
-    )
-    result = testdir.runpytest()
-    assert_outcomes(result, errors=1)
-    result.stdout.fnmatch_lines(
-        "*Scenario has not valid examples. Example rows should contain unique parameters. "
-        '"start" appeared more than once.*'
-    )
-
-
-def test_wrong_vertical_examples_feature(testdir):
-    """Test parametrized feature vertical example table has wrong format."""
-    testdir.makefile(
-        ".feature",
-        outline=textwrap.dedent(
-            """\
-            Feature: Outlines
-
-                Examples: Vertical
-                | start | 12 | 2 |
-                | start | 10 | 1 |
-                | left  | 7  | 1 |
-
-                Scenario Outline: Outlined with wrong vertical example table
-                    Given there are <start> cucumbers
-                    When I eat <eat> cucumbers
-                    Then I should have <left> cucumbers
-            """
-        ),
-    )
-    testdir.makeconftest(textwrap.dedent(STEPS))
-
-    testdir.makepyfile(
-        textwrap.dedent(
-            """\
-        from pytest_bdd import scenario
-
-        @scenario("outline.feature", "Outlined with wrong vertical example table")
-        def test_outline(request):
-            pass
-        """
-        )
-    )
-    result = testdir.runpytest()
-    assert_outcomes(result, errors=1)
-    result.stdout.fnmatch_lines(
-        "*Feature has not valid examples. Example rows should contain unique parameters. "
-        '"start" appeared more than once.*'
-    )
-
-
 def test_outlined_with_other_fixtures(testdir):
     """Test outlined scenario also using other parametrized fixture."""
     testdir.makefile(
@@ -298,6 +217,87 @@ def test_vertical_example(testdir):
         2, 1.0, "1",
     ]
     # fmt: on
+
+
+def test_wrong_vertical_examples_scenario(testdir):
+    """Test parametrized scenario vertical example table has wrong format."""
+    testdir.makefile(
+        ".feature",
+        outline=textwrap.dedent(
+            """\
+            Feature: Outline
+                Scenario Outline: Outlined with wrong vertical example table
+                    Given there are <start> cucumbers
+                    When I eat <eat> cucumbers
+                    Then I should have <left> cucumbers
+
+                    Examples: Vertical
+                    | start | 12 | 2 |
+                    | start | 10 | 1 |
+                    | left  | 7  | 1 |
+            """
+        ),
+    )
+    testdir.makeconftest(textwrap.dedent(STEPS))
+
+    testdir.makepyfile(
+        textwrap.dedent(
+            """\
+        from pytest_bdd import scenario
+
+        @scenario("outline.feature", "Outlined with wrong vertical example table")
+        def test_outline(request):
+            pass
+        """
+        )
+    )
+    result = testdir.runpytest()
+    assert_outcomes(result, errors=1)
+    result.stdout.fnmatch_lines(
+        "*Scenario has not valid examples. Example rows should contain unique parameters. "
+        '"start" appeared more than once.*'
+    )
+
+
+def test_wrong_vertical_examples_feature(testdir):
+    """Test parametrized feature vertical example table has wrong format."""
+    testdir.makefile(
+        ".feature",
+        outline=textwrap.dedent(
+            """\
+            Feature: Outlines
+
+                Examples: Vertical
+                | start | 12 | 2 |
+                | start | 10 | 1 |
+                | left  | 7  | 1 |
+
+                Scenario Outline: Outlined with wrong vertical example table
+                    Given there are <start> cucumbers
+                    When I eat <eat> cucumbers
+                    Then I should have <left> cucumbers
+            """
+        ),
+    )
+    testdir.makeconftest(textwrap.dedent(STEPS))
+
+    testdir.makepyfile(
+        textwrap.dedent(
+            """\
+        from pytest_bdd import scenario
+
+        @scenario("outline.feature", "Outlined with wrong vertical example table")
+        def test_outline(request):
+            pass
+        """
+        )
+    )
+    result = testdir.runpytest()
+    assert_outcomes(result, errors=1)
+    result.stdout.fnmatch_lines(
+        "*Feature has not valid examples. Example rows should contain unique parameters. "
+        '"start" appeared more than once.*'
+    )
 
 
 def test_outlined_feature(testdir):

--- a/tests/feature/test_report.py
+++ b/tests/feature/test_report.py
@@ -1,7 +1,7 @@
 """Test scenario reporting."""
 import textwrap
 
-import pytest
+import execnet.gateway_base
 
 
 class OfType:
@@ -171,7 +171,9 @@ def test_step_trace(testdir):
     }
     assert report == expected
 
-    report = result.matchreport("test_outlined[12-5-7]", when="call").scenario
+    report = result.matchreport(
+        "test_outlined[[Scenario:Outlined:line_no:14]>[Examples:[Empty]:line_no:19]>[Row:0]:12-5-7]", when="call"
+    ).scenario
     expected = {
         "feature": {
             "description": "",
@@ -213,7 +215,9 @@ def test_step_trace(testdir):
     }
     assert report == expected
 
-    report = result.matchreport("test_outlined[5-4-1]", when="call").scenario
+    report = result.matchreport(
+        "test_outlined[[Scenario:Outlined:line_no:14]>[Examples:[Empty]:line_no:19]>[Row:1]:5-4-1]", when="call"
+    ).scenario
     expected = {
         "feature": {
             "description": "",
@@ -258,10 +262,6 @@ def test_step_trace(testdir):
 
 def test_complex_types(testdir, pytestconfig):
     """Test serialization of the complex types."""
-    if not pytestconfig.pluginmanager.has_plugin("xdist"):
-        pytest.skip("Execnet not installed")
-
-    import execnet.gateway_base
 
     testdir.makefile(
         ".feature",
@@ -316,7 +316,9 @@ def test_complex_types(testdir, pytestconfig):
         )
     )
     result = testdir.inline_run("-vvl")
-    report = result.matchreport("test_complex[10,20-alien0]", when="call")
+    report = result.matchreport(
+        "test_complex[[Scenario:Complex:line_no:3]>[Examples:[Empty]:line_no:6]>[Row:0]:10,20-alien0]", when="call"
+    )
     assert report.passed
     assert execnet.gateway_base.dumps(report.item)
     assert execnet.gateway_base.dumps(report.scenario)


### PR DESCRIPTION
In most cases, cfparse parser is more useful than a string parser. It could be used almost everywhere, just one edge-case is when the step definition contains "{....}" pair. In this case user still could select string parser