### PR TITLE
Fix some defects in Outlined scenarios tests and add more tests

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -637,6 +637,33 @@ This is allowed as long as parameter names do not clash:
             | carrots    |
             | tomatoes   |
 
+To not repeat steps as in example above you could want store your data in sequent Examples sections:
+
+
+.. code-block:: gherkin
+
+    Feature: Outline
+
+        Examples:
+        | start | eat | left |
+        |  12   |  5  |  7   |
+        |  5    |  4  |  1   |
+
+        Scenario Outline: Eat food
+            Given there are <start> <food>
+            When I eat <eat> <food>
+            Then I should have <left> <food>
+
+            Examples: Fruits
+            | food    |
+            | oranges |
+            | apples  |
+
+            Examples: Vegetables
+            | food       |
+            | carrots    |
+            | tomatoes   |
+
 
 Organizing your scenarios
 -------------------------

--- a/pytest_bdd/parser.py
+++ b/pytest_bdd/parser.py
@@ -7,7 +7,7 @@ from itertools import chain, product, zip_longest
 from typing import List
 
 import pytest
-from attr import attrs, attrib, Factory, validate
+from attr import Factory, attrib, attrs, validate
 
 from . import exceptions, types
 

--- a/pytest_bdd/parser.py
+++ b/pytest_bdd/parser.py
@@ -283,9 +283,13 @@ class ScenarioTemplate:
 
         def examples():
             for feature_examples, scenario_examples in feature_scenario_examples_combinations:
-                result = {**feature_examples, **scenario_examples}
-                if result != {}:
-                    yield result
+                common_param_names = set(feature_examples.keys()).intersection(scenario_examples.keys())
+                if all(
+                    feature_examples[param_name] == scenario_examples[param_name] for param_name in common_param_names
+                ):
+                    result = {**feature_examples, **scenario_examples}
+                    if result != {}:
+                        yield result
 
         return [pytest.param(example, id="-".join(example.values())) for example in examples()]
 

--- a/pytest_bdd/parser.py
+++ b/pytest_bdd/parser.py
@@ -183,17 +183,21 @@ def parse_feature(basedir: str, filename: str, encoding: str = "utf-8") -> "Feat
                 message = f"{node_message_prefix} has not valid examples. {exc.args[0]}"
                 raise exceptions.FeatureError(message, line_number, clean_line, filename) from exc
         elif mode == types.EXAMPLE_LINE_VERTICAL:
-            param, *examples = split_line(stripped_line)
             try:
-                build_example_table: ExampleTableRows
-                build_example_table.example_params += [param]
-                build_example_table.examples_transposed += [examples]
-                validate(build_example_table)
-            except exceptions.ExamplesNotValidError as exc:
-                message = "{node} has not valid examples. {original_message}".format(
-                    node="Scenario" if scenario else "Feature", original_message=exc.args[0]
-                )
-                raise exceptions.FeatureError(message, line_number, clean_line, filename) from exc
+                param, *examples = split_line(stripped_line)
+            except ValueError:
+                pass
+            else:
+                try:
+                    build_example_table: ExampleTableRows
+                    build_example_table.example_params += [param]
+                    build_example_table.examples_transposed += [examples]
+                    validate(build_example_table)
+                except exceptions.ExamplesNotValidError as exc:
+                    message = "{node} has not valid examples. {original_message}".format(
+                        node="Scenario" if scenario else "Feature", original_message=exc.args[0]
+                    )
+                    raise exceptions.FeatureError(message, line_number, clean_line, filename) from exc
         elif mode and mode not in (types.FEATURE, types.TAG):
             step = Step(name=parsed_line, type=mode, indent=line_indent, line_number=line_number, keyword=keyword)
             if feature.background and not scenario:

--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -1,1 +1,3 @@
+execnet
+deepdiff
 packaging

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,7 @@ classifiers =
 [options]
 python_requires = >=3.6
 install_requires =
+    attrs
     glob2
     Mako
     parse

--- a/tests/feature/test_cucumber_json.py
+++ b/tests/feature/test_cucumber_json.py
@@ -3,6 +3,8 @@ import json
 import os.path
 import textwrap
 
+from deepdiff import DeepDiff
+
 
 def runandparse(testdir, *args):
     """Run tests in testdir and parse json output."""
@@ -225,4 +227,4 @@ def test_step_trace(testdir):
         }
     ]
 
-    assert jsonobject == expected
+    assert DeepDiff(jsonobject, expected, ignore_order=True, report_repetition=True)

--- a/tests/feature/test_outline.py
+++ b/tests/feature/test_outline.py
@@ -539,6 +539,53 @@ def test_multi_outlined(testdir):
     # fmt: on
 
 
+@pytest.mark.xfail(reason="https://github.com/pytest-dev/pytest-bdd/issues/480")
+def test_multi_outlined_empty_examples(testdir):
+    testdir.makefile(
+        ".feature",
+        outline=textwrap.dedent(
+            """\
+            Feature: Outline
+
+                Examples:
+
+                Examples: Vertical
+
+                Examples:
+                |
+
+                Examples: Vertical
+                |
+
+                Scenario Outline: Outlined given, when, thens
+                    Given there are 12 apples
+                    When I eat 5 apples
+                    Then I should have 7 apples
+
+                    Examples:
+
+                    Examples: Vertical
+
+                    Examples:
+                    |
+
+                    Examples: Vertical
+                    |
+            """
+        ),
+    )
+
+    testdir.makepyfile(STEPS_OUTLINED)
+    result = testdir.runpytest("-s")
+    result.assert_outcomes(passed=1)
+    parametrizations = collect_dumped_objects(result)
+    # fmt: off
+    assert parametrizations == [
+        12, "apples", 5.0, "apples", "7", "apples",
+    ]
+    # fmt: on
+
+
 def test_multi_outlined_feature_with_parameter_union(testdir):
     testdir.makefile(
         ".feature",

--- a/tests/feature/test_outline.py
+++ b/tests/feature/test_outline.py
@@ -539,7 +539,6 @@ def test_multi_outlined(testdir):
     # fmt: on
 
 
-@pytest.mark.xfail(reason="https://github.com/pytest-dev/pytest-bdd/issues/480")
 def test_multi_outlined_empty_examples(testdir):
     testdir.makefile(
         ".feature",

--- a/tests/feature/test_outline.py
+++ b/tests/feature/test_outline.py
@@ -167,6 +167,86 @@ def test_wrongly_outlined_extra_parameter(testdir):
     result.stdout.fnmatch_lines("*should match set of example values [[]'eat', 'left', 'start', 'unknown_param'[]].*")
 
 
+def test_wrongly_outlined_duplicated_parameter_scenario(testdir):
+    """Test parametrized scenario vertical example table has wrong format."""
+    testdir.makefile(
+        ".feature",
+        outline=textwrap.dedent(
+            """\
+            Feature: Outline
+                Scenario Outline: Outlined with wrong vertical example table
+                    Given there are <start> cucumbers
+                    When I eat <eat> cucumbers
+                    Then I should have <left> cucumbers
+
+                    Examples:
+                    | start | start | left |
+                    |   12  |   10  |   7  |
+                    |    2  |    1  |   1  |
+            """
+        ),
+    )
+    testdir.makeconftest(textwrap.dedent(STEPS))
+
+    testdir.makepyfile(
+        textwrap.dedent(
+            """\
+        from pytest_bdd import scenario
+
+        @scenario("outline.feature", "Outlined with wrong vertical example table")
+        def test_outline(request):
+            pass
+        """
+        )
+    )
+    result = testdir.runpytest()
+    assert_outcomes(result, errors=1)
+    result.stdout.fnmatch_lines(
+        "*Scenario has not valid examples. Example rows should contain unique parameters. "
+        '"start" appeared more than once.*'
+    )
+
+
+def test_wrongly_outlined_duplicated_parameter_feature(testdir):
+    """Test parametrized scenario vertical example table has wrong format."""
+    testdir.makefile(
+        ".feature",
+        outline=textwrap.dedent(
+            """\
+            Feature: Outline
+                Examples:
+                 | start | start | left |
+                 |   12  |   10  |   7  |
+                 |    2  |    1  |   1  |
+
+                Scenario Outline: Outlined with wrong vertical example table
+                    Given there are <start> cucumbers
+                    When I eat <eat> cucumbers
+                    Then I should have <left> cucumbers
+            """
+        ),
+    )
+    testdir.makeconftest(textwrap.dedent(STEPS))
+
+    testdir.makepyfile(
+        textwrap.dedent(
+            """\
+        from pytest_bdd import scenario
+
+        @scenario("outline.feature", "Outlined with wrong vertical example table")
+        def test_outline(request):
+            pass
+        """
+        )
+    )
+    result = testdir.runpytest()
+    assert_outcomes(result, errors=1)
+    result.stdout.fnmatch_lines(
+        "*Feature has not valid examples. Example rows should contain unique parameters. "
+        '"start" appeared more than once.*'
+    )
+
+
 def test_outlined_with_other_fixtures(testdir):
     """Test outlined scenario also using other parametrized fixture."""
     testdir.makefile(

--- a/tests/feature/test_outline.py
+++ b/tests/feature/test_outline.py
@@ -489,7 +489,6 @@ def test_outline_with_escaped_pipes(testdir):
     ]
 
 
-@pytest.mark.xfail(reason="https://github.com/pytest-dev/pytest-bdd/issues/479")
 def test_multi_outlined(testdir):
     testdir.makefile(
         ".feature",
@@ -540,7 +539,6 @@ def test_multi_outlined(testdir):
     # fmt: on
 
 
-@pytest.mark.xfail(reason="https://github.com/pytest-dev/pytest-bdd/issues/479")
 def test_multi_outlined_feature_with_parameter_union(testdir):
     testdir.makefile(
         ".feature",
@@ -584,7 +582,6 @@ def test_multi_outlined_feature_with_parameter_union(testdir):
     # fmt: on
 
 
-@pytest.mark.xfail(reason="https://github.com/pytest-dev/pytest-bdd/issues/479")
 def test_multi_outlined_scenario_and_feature_with_parameter_union(testdir):
     testdir.makefile(
         ".feature",

--- a/tests/feature/test_outline.py
+++ b/tests/feature/test_outline.py
@@ -860,7 +860,7 @@ def test_outlined_scenario_and_feature_with_parameter_join_by_multi_parameter_un
                     | fruits    | eat | left |
                     | apples    |  5  |  7   |
                     | oranges   |  4  |  1   |
-                    | cucumbers |  5  |  7   | 
+                    | cucumbers |  5  |  7   |
 
                     Examples:
                     | fruits     |

--- a/tests/feature/test_outline.py
+++ b/tests/feature/test_outline.py
@@ -122,87 +122,6 @@ def test_wrongly_outlined(testdir):
     result.stdout.fnmatch_lines("*should match set of example values [[]'eat', 'left', 'start', 'unknown_param'[]].*")
 
 
-def test_wrong_vertical_examples_scenario(testdir):
-    """Test parametrized scenario vertical example table has wrong format."""
-    testdir.makefile(
-        ".feature",
-        outline=textwrap.dedent(
-            """\
-            Feature: Outline
-                Scenario Outline: Outlined with wrong vertical example table
-                    Given there are <start> cucumbers
-                    When I eat <eat> cucumbers
-                    Then I should have <left> cucumbers
-
-                    Examples: Vertical
-                    | start | 12 | 2 |
-                    | start | 10 | 1 |
-                    | left  | 7  | 1 |
-            """
-        ),
-    )
-    testdir.makeconftest(textwrap.dedent(STEPS))
-
-    testdir.makepyfile(
-        textwrap.dedent(
-            """\
-        from pytest_bdd import scenario
-
-        @scenario("outline.feature", "Outlined with wrong vertical example table")
-        def test_outline(request):
-            pass
-        """
-        )
-    )
-    result = testdir.runpytest()
-    assert_outcomes(result, errors=1)
-    result.stdout.fnmatch_lines(
-        "*Scenario has not valid examples. Example rows should contain unique parameters. "
-        '"start" appeared more than once.*'
-    )
-
-
-def test_wrong_vertical_examples_feature(testdir):
-    """Test parametrized feature vertical example table has wrong format."""
-    testdir.makefile(
-        ".feature",
-        outline=textwrap.dedent(
-            """\
-            Feature: Outlines
-
-                Examples: Vertical
-                | start | 12 | 2 |
-                | start | 10 | 1 |
-                | left  | 7  | 1 |
-
-                Scenario Outline: Outlined with wrong vertical example table
-                    Given there are <start> cucumbers
-                    When I eat <eat> cucumbers
-                    Then I should have <left> cucumbers
-            """
-        ),
-    )
-    testdir.makeconftest(textwrap.dedent(STEPS))
-
-    testdir.makepyfile(
-        textwrap.dedent(
-            """\
-        from pytest_bdd import scenario
-
-        @scenario("outline.feature", "Outlined with wrong vertical example table")
-        def test_outline(request):
-            pass
-        """
-        )
-    )
-    result = testdir.runpytest()
-    assert_outcomes(result, errors=1)
-    result.stdout.fnmatch_lines(
-        "*Feature has not valid examples. Example rows should contain unique parameters. "
-        '"start" appeared more than once.*'
-    )
-
-
 def test_outlined_with_other_fixtures(testdir):
     """Test outlined scenario also using other parametrized fixture."""
     testdir.makefile(
@@ -298,6 +217,87 @@ def test_vertical_example(testdir):
         2, 1.0, "1",
     ]
     # fmt: on
+
+
+def test_wrong_vertical_examples_scenario(testdir):
+    """Test parametrized scenario vertical example table has wrong format."""
+    testdir.makefile(
+        ".feature",
+        outline=textwrap.dedent(
+            """\
+            Feature: Outline
+                Scenario Outline: Outlined with wrong vertical example table
+                    Given there are <start> cucumbers
+                    When I eat <eat> cucumbers
+                    Then I should have <left> cucumbers
+
+                    Examples: Vertical
+                    | start | 12 | 2 |
+                    | start | 10 | 1 |
+                    | left  | 7  | 1 |
+            """
+        ),
+    )
+    testdir.makeconftest(textwrap.dedent(STEPS))
+
+    testdir.makepyfile(
+        textwrap.dedent(
+            """\
+        from pytest_bdd import scenario
+
+        @scenario("outline.feature", "Outlined with wrong vertical example table")
+        def test_outline(request):
+            pass
+        """
+        )
+    )
+    result = testdir.runpytest()
+    assert_outcomes(result, errors=1)
+    result.stdout.fnmatch_lines(
+        "*Scenario has not valid examples. Example rows should contain unique parameters. "
+        '"start" appeared more than once.*'
+    )
+
+
+def test_wrong_vertical_examples_feature(testdir):
+    """Test parametrized feature vertical example table has wrong format."""
+    testdir.makefile(
+        ".feature",
+        outline=textwrap.dedent(
+            """\
+            Feature: Outlines
+
+                Examples: Vertical
+                | start | 12 | 2 |
+                | start | 10 | 1 |
+                | left  | 7  | 1 |
+
+                Scenario Outline: Outlined with wrong vertical example table
+                    Given there are <start> cucumbers
+                    When I eat <eat> cucumbers
+                    Then I should have <left> cucumbers
+            """
+        ),
+    )
+    testdir.makeconftest(textwrap.dedent(STEPS))
+
+    testdir.makepyfile(
+        textwrap.dedent(
+            """\
+        from pytest_bdd import scenario
+
+        @scenario("outline.feature", "Outlined with wrong vertical example table")
+        def test_outline(request):
+            pass
+        """
+        )
+    )
+    result = testdir.runpytest()
+    assert_outcomes(result, errors=1)
+    result.stdout.fnmatch_lines(
+        "*Feature has not valid examples. Example rows should contain unique parameters. "
+        '"start" appeared more than once.*'
+    )
 
 
 def test_outlined_feature(testdir):

--- a/tests/feature/test_outline.py
+++ b/tests/feature/test_outline.py
@@ -751,3 +751,140 @@ def test_multi_outlined_scenario_and_feature_with_parameter_union(testdir):
         5, "apples", 4.0, "apples", "1", "apples",
     ]
     # fmt: on
+
+
+@pytest.mark.xfail
+def test_outlined_scenario_and_feature_with_parameter_join_by_one_parameter(testdir):
+    testdir.makefile(
+        ".feature",
+        outline=textwrap.dedent(
+            """\
+            Feature: Outline
+
+                Examples:
+                | start | eat | left |
+                |  12   |  5  |  7   |
+                |   5   |  4  |  1   |
+
+
+                Scenario Outline: Outlined given, when, thens
+                    Given there are <start> <fruits>
+                    When I eat <eat> <fruits>
+                    Then I should have <left> <fruits>
+
+                    Examples:
+                    | fruits  | left |
+                    | apples  |  7   |
+                    | oranges |  1   |
+            """
+        ),
+    )
+
+    testdir.makepyfile(STEPS_OUTLINED)
+    result = testdir.runpytest("-s")
+    result.assert_outcomes(passed=2)
+    parametrizations = collect_dumped_objects(result)
+    # fmt: off
+    assert parametrizations == [
+        12, "apples", 5.0, "apples", "7", "apples",
+        5, "oranges", 4.0, "oranges", "1", "oranges",
+    ]
+    # fmt: on
+
+
+@pytest.mark.xfail
+def test_outlined_scenario_and_feature_with_parameter_join_by_multi_parameter(testdir):
+    testdir.makefile(
+        ".feature",
+        outline=textwrap.dedent(
+            """\
+            Feature: Outline
+
+                Examples:
+                | fruits    | start | eat | left |
+                | apples    |  12   |  5  |  7   |
+                | apples    |  12   |  9  |  3   |  # not joined by <eat> <left>
+                | oranges   |   5   |  4  |  1   |
+                | cucumbers |   8   |  3  |  5   |  # not joined by <eat> <left>
+
+
+                Scenario Outline: Outlined given, when, thens
+                    Given there are <start> <fruits>
+                    When I eat <eat> <fruits>
+                    Then I should have <left> <fruits>
+
+                    Examples:
+                    | fruits    | eat | left |
+                    | apples    |  5  |  7   |
+                    | oranges   |  4  |  1   |
+                    | cucumbers |  5  |  7   |  # not joined by <fruits>
+            """
+        ),
+    )
+
+    testdir.makepyfile(STEPS_OUTLINED)
+    result = testdir.runpytest("-s")
+    result.assert_outcomes(passed=2)
+    parametrizations = collect_dumped_objects(result)
+    # fmt: off
+    assert parametrizations == [
+        12, "apples", 5.0, "apples", "7", "apples",
+        5, "oranges", 4.0, "oranges", "1", "oranges",
+    ]
+    # fmt: on
+
+
+@pytest.mark.xfail
+def test_outlined_scenario_and_feature_with_parameter_join_by_multi_parameter_unbalanced(testdir):
+    testdir.makefile(
+        ".feature",
+        outline=textwrap.dedent(
+            """\
+            Feature: Outline
+                Examples:
+                | start | eat | left |
+                |  14   |  6  |  8   |
+                |  15   |  5  |  10   |
+
+                Examples:
+                | fruits    | start | eat | left |
+                | apples    |  12   |  5  |  7   |
+                | apples    |  12   |  9  |  3   |
+                | oranges   |   5   |  4  |  1   |
+                | cucumbers |   8   |  3  |  5   |
+
+
+                Scenario Outline: Outlined given, when, thens
+                    Given there are <start> <fruits>
+                    When I eat <eat> <fruits>
+                    Then I should have <left> <fruits>
+
+                    Examples:
+                    | fruits    | eat | left |
+                    | apples    |  5  |  7   |
+                    | oranges   |  4  |  1   |
+                    | cucumbers |  5  |  7   | 
+
+                    Examples:
+                    | fruits     |
+                    | pineapples |
+                    | peaches    |
+
+            """
+        ),
+    )
+
+    testdir.makepyfile(STEPS_OUTLINED)
+    result = testdir.runpytest("-s")
+    result.assert_outcomes(passed=6)
+    parametrizations = collect_dumped_objects(result)
+    # fmt: off
+    assert parametrizations == [
+        14, 'pineapples', 6.0, 'pineapples', '8', 'pineapples',
+        14, 'peaches', 6.0, 'peaches', '8', 'peaches',
+        15, 'pineapples', 5.0, 'pineapples', '10', 'pineapples',
+        15, 'peaches', 5.0, 'peaches', '10', 'peaches',
+        12, 'apples', 5.0, 'apples', '7', 'apples',
+        5, 'oranges', 4.0, 'oranges', '1', 'oranges'
+    ]
+    # fmt: on

--- a/tests/feature/test_outline.py
+++ b/tests/feature/test_outline.py
@@ -753,7 +753,6 @@ def test_multi_outlined_scenario_and_feature_with_parameter_union(testdir):
     # fmt: on
 
 
-@pytest.mark.xfail
 def test_outlined_scenario_and_feature_with_parameter_join_by_one_parameter(testdir):
     testdir.makefile(
         ".feature",
@@ -792,7 +791,6 @@ def test_outlined_scenario_and_feature_with_parameter_join_by_one_parameter(test
     # fmt: on
 
 
-@pytest.mark.xfail
 def test_outlined_scenario_and_feature_with_parameter_join_by_multi_parameter(testdir):
     testdir.makefile(
         ".feature",
@@ -834,7 +832,6 @@ def test_outlined_scenario_and_feature_with_parameter_join_by_multi_parameter(te
     # fmt: on
 
 
-@pytest.mark.xfail
 def test_outlined_scenario_and_feature_with_parameter_join_by_multi_parameter_unbalanced(testdir):
     testdir.makefile(
         ".feature",
@@ -869,7 +866,6 @@ def test_outlined_scenario_and_feature_with_parameter_join_by_multi_parameter_un
                     | fruits     |
                     | pineapples |
                     | peaches    |
-
             """
         ),
     )

--- a/tests/feature/test_report.py
+++ b/tests/feature/test_report.py
@@ -1,8 +1,6 @@
 """Test scenario reporting."""
 import textwrap
 
-import pytest
-
 
 class OfType:
     """Helper object comparison to which is always 'equal'."""
@@ -256,10 +254,8 @@ def test_step_trace(testdir):
     assert report == expected
 
 
-def test_complex_types(testdir, pytestconfig):
+def test_complex_types(testdir):
     """Test serialization of the complex types."""
-    if not pytestconfig.pluginmanager.has_plugin("xdist"):
-        pytest.skip("Execnet not installed")
 
     import execnet.gateway_base
 


### PR DESCRIPTION
- Fixed union of Examples and Examples: Vertical
- Fixed blinking defect of join Examples on Feature and Scenario Outline level
- Fixed empty Examples: vertical tables which contain "|" only
- Add named Examples sections validation into tests
- Found extra semantic for Examples tables joining on Feature and Scenario Outline levels
- There are still failing tests (good that found, defects are still there and would be closed by another PR)