### PR TITLE
Preparing the scenario for multiple example tables

### DIFF
--- a/pytest_bdd/parser.py
+++ b/pytest_bdd/parser.py
@@ -228,9 +228,14 @@ class ScenarioTemplate:
         self.feature = feature
         self.name = name
         self._steps: typing.List[Step] = []
-        self.examples = Examples()
+        self.example_tables = [Examples()]
         self.line_number = line_number
         self.tags = tags or set()
+
+    @property
+    def examples(self):
+        """Current examples."""
+        return self.example_tables[-1]
 
     def add_step(self, step):
         """Add step to the scenario.
@@ -246,6 +251,7 @@ class ScenarioTemplate:
         return (background.steps if background else []) + self._steps
 
     def render(self, context: typing.Mapping[str, typing.Any]) -> "Scenario":
+        """Render a single scenario given a context (examples)."""
         steps = [
             Step(
                 name=templated_step.render(context),


### PR DESCRIPTION
Cucumber has added multiple example tables to the scenarios. These examples can also get tags.
We need to support pytest marks for those examples.
The parser is going to add multiple example tables to the TemplatedScenario. The tags can become part of the Examples object.
Since each test item is produced by the parametrization represented by a single table row we have to pass the marks parameter to each of them.