### PR TITLE
Feature examples removal. Compatibility with official gherkin

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+Unreleased
+----------
+
+- Cleanup of the documentation and tests related to parametrization (elchupanebrej)
+- Removed feature level examples for gherkin compatibility (olegpidsadnyi)
+
+
+
 5.0.0
 -----
 This release introduces breaking changes, please refer to the :ref:`Migration from 4.x.x`.

--- a/README.rst
+++ b/README.rst
@@ -506,7 +506,7 @@ Scenario outlines
 Scenarios can be parametrized to cover few cases. In Gherkin the variable
 templates are written using corner braces as ``<somevalue>``.
 `Gherkin scenario outlines <http://behat.org/en/v3.0/user_guide/writing_scenarios.html#scenario-outlines>`_ are supported by pytest-bdd
-exactly as it's described in be behave_ docs.
+exactly as it's described in the behave_ docs.
 
 Example:
 
@@ -578,64 +578,6 @@ The code will look like:
 Example code also shows possibility to pass example converters which may be useful if you need parameter types
 different than strings.
 
-
-Feature examples
-^^^^^^^^^^^^^^^^
-
-It's possible to declare example table once for the whole feature, and it will be shared
-among all the scenarios of that feature:
-
-.. code-block:: gherkin
-
-    Feature: Outline
-
-        Examples:
-        | start | eat | left |
-        |  12   |  5  |  7   |
-        |  5    |  4  |  1   |
-
-        Scenario Outline: Eat cucumbers
-            Given there are <start> cucumbers
-            When I eat <eat> cucumbers
-            Then I should have <left> cucumbers
-
-        Scenario Outline: Eat apples
-            Given there are <start> apples
-            When I eat <eat> apples
-            Then I should have <left> apples
-
-For some more complex case, you might want to parametrize on both levels: feature and scenario.
-This is allowed as long as parameter names do not clash:
-
-
-.. code-block:: gherkin
-
-    Feature: Outline
-
-        Examples:
-        | start | eat | left |
-        |  12   |  5  |  7   |
-        |  5    |  4  |  1   |
-
-        Scenario Outline: Eat fruits
-            Given there are <start> <fruits>
-            When I eat <eat> <fruits>
-            Then I should have <left> <fruits>
-
-            Examples:
-            | fruits  |
-            | oranges |
-            | apples  |
-
-        Scenario Outline: Eat vegetables
-            Given there are <start> <vegetables>
-            When I eat <eat> <vegetables>
-            Then I should have <left> <vegetables>
-
-            Examples:
-            | vegetables |
-            | carrots    |
-            | tomatoes   |
 
 
 Organizing your scenarios

--- a/pytest_bdd/__init__.py
+++ b/pytest_bdd/__init__.py
@@ -3,6 +3,6 @@
 from pytest_bdd.scenario import scenario, scenarios
 from pytest_bdd.steps import given, then, when
 
-__version__ = "5.0.0"
+__version__ = "6.0.0"
 
 __all__ = [given.__name__, when.__name__, then.__name__, scenario.__name__, scenarios.__name__]

--- a/pytest_bdd/parser.py
+++ b/pytest_bdd/parser.py
@@ -90,7 +90,6 @@ def parse_feature(basedir: str, filename: str, encoding: str = "utf-8") -> "Feat
         line_number=1,
         name=None,
         tags=set(),
-        examples=Examples(),
         background=None,
         description="",
     )
@@ -157,34 +156,27 @@ def parse_feature(basedir: str, filename: str, encoding: str = "utf-8") -> "Feat
             feature.background = Background(feature=feature, line_number=line_number)
         elif mode == types.EXAMPLES:
             mode = types.EXAMPLES_HEADERS
-            (scenario or feature).examples.line_number = line_number
+            scenario.examples.line_number = line_number
         elif mode == types.EXAMPLES_VERTICAL:
             mode = types.EXAMPLE_LINE_VERTICAL
-            (scenario or feature).examples.line_number = line_number
+            scenario.examples.line_number = line_number
         elif mode == types.EXAMPLES_HEADERS:
-            (scenario or feature).examples.set_param_names([l for l in split_line(parsed_line) if l])
+            scenario.examples.set_param_names([l for l in split_line(parsed_line) if l])
             mode = types.EXAMPLE_LINE
         elif mode == types.EXAMPLE_LINE:
-            (scenario or feature).examples.add_example([l for l in split_line(stripped_line)])
+            scenario.examples.add_example([l for l in split_line(stripped_line)])
         elif mode == types.EXAMPLE_LINE_VERTICAL:
             param_line_parts = [l for l in split_line(stripped_line)]
             try:
-                (scenario or feature).examples.add_example_row(param_line_parts[0], param_line_parts[1:])
+                scenario.examples.add_example_row(param_line_parts[0], param_line_parts[1:])
             except exceptions.ExamplesNotValidError as exc:
-                if scenario:
-                    raise exceptions.FeatureError(
-                        f"Scenario has not valid examples. {exc.args[0]}",
-                        line_number,
-                        clean_line,
-                        filename,
-                    )
-                else:
-                    raise exceptions.FeatureError(
-                        f"Feature has not valid examples. {exc.args[0]}",
-                        line_number,
-                        clean_line,
-                        filename,
-                    )
+                raise exceptions.FeatureError(
+                    f"Scenario has not valid examples. {exc.args[0]}",
+                    line_number,
+                    clean_line,
+                    filename,
+                )
+
         elif mode and mode not in (types.FEATURE, types.TAG):
             step = Step(name=parsed_line, type=mode, indent=line_indent, line_number=line_number, keyword=keyword)
             if feature.background and not scenario:
@@ -201,12 +193,11 @@ def parse_feature(basedir: str, filename: str, encoding: str = "utf-8") -> "Feat
 class Feature:
     """Feature."""
 
-    def __init__(self, scenarios, filename, rel_filename, name, tags, examples, background, line_number, description):
+    def __init__(self, scenarios, filename, rel_filename, name, tags, background, line_number, description):
         self.scenarios: typing.Dict[str, ScenarioTemplate] = scenarios
         self.rel_filename = rel_filename
         self.filename = filename
         self.tags = tags
-        self.examples = examples
         self.name = name
         self.line_number = line_number
         self.description = description
@@ -264,7 +255,7 @@ class ScenarioTemplate:
         :raises ScenarioValidationError: when scenario is not valid
         """
         params = frozenset(sum((list(step.params) for step in self.steps), []))
-        example_params = set(self.examples.example_params + self.feature.examples.example_params)
+        example_params = set(self.examples.example_params)
         if params and example_params and params != example_params:
             raise exceptions.ScenarioExamplesNotValidError(
                 """Scenario "{}" in the feature "{}" has not valid examples. """

--- a/pytest_bdd/scenario.py
+++ b/pytest_bdd/scenario.py
@@ -199,19 +199,10 @@ def collect_example_parametrizations(
 ) -> "typing.Optional[typing.List[ParameterSet]]":
     # We need to evaluate these iterators and store them as lists, otherwise
     # we won't be able to do the cartesian product later (the second iterator will be consumed)
-    feature_contexts = list(templated_scenario.feature.examples.as_contexts())
-    scenario_contexts = list(templated_scenario.examples.as_contexts())
-
-    contexts = [
-        {**feature_context, **scenario_context}
-        # We must make sure that we always have at least one element in each list, otherwise
-        # the cartesian product will result in an empty list too, even if one of the 2 sets
-        # is non empty.
-        for feature_context in feature_contexts or [{}]
-        for scenario_context in scenario_contexts or [{}]
-    ]
-    if contexts == [{}]:
+    contexts = list(templated_scenario.examples.as_contexts())
+    if not contexts:
         return None
+
     return [pytest.param(context, id="-".join(context.values())) for context in contexts]
 
 


### PR DESCRIPTION
Gherkin 6 is becoming more complex. In order to be compatible with all the changes like multiple scenario examples we should remove our own complexity.
The spirit of pytest-bdd 6 would be gherkin compatibility.
This PR is removing the examples on the feature level.