### PR TITLE
remove unused example param validation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,7 @@ This release introduces breaking changes in order to be more in line with the of
 - Removed feature level examples for the gherkin compatibility (olegpidsadnyi)
 - Removed vertical examples for the gherkin compatibility (olegpidsadnyi)
 - Step arguments are no longer fixtures (olegpidsadnyi)
+- Scenario outlines unused example parameter validation is removed (olegpidsadnyi)
 
 
 

--- a/pytest_bdd/cucumber_json.py
+++ b/pytest_bdd/cucumber_json.py
@@ -61,7 +61,7 @@ class LogBDDCucumberJSON:
             result = {"status": "failed", "error_message": str(report.longrepr) if error_message else ""}
         elif report.skipped:
             result = {"status": "skipped"}
-        result["duration"] = int(math.floor((10 ** 9) * step["duration"]))  # nanosec
+        result["duration"] = int(math.floor((10**9) * step["duration"]))  # nanosec
         return result
 
     def _serialize_tags(self, item):

--- a/pytest_bdd/cucumber_json.py
+++ b/pytest_bdd/cucumber_json.py
@@ -61,7 +61,7 @@ class LogBDDCucumberJSON:
             result = {"status": "failed", "error_message": str(report.longrepr) if error_message else ""}
         elif report.skipped:
             result = {"status": "skipped"}
-        result["duration"] = int(math.floor((10**9) * step["duration"]))  # nanosec
+        result["duration"] = int(math.floor((10 ** 9) * step["duration"]))  # nanosec
         return result
 
     def _serialize_tags(self, item):

--- a/pytest_bdd/exceptions.py
+++ b/pytest_bdd/exceptions.py
@@ -17,14 +17,6 @@ class ExamplesNotValidError(ScenarioValidationError):
     """Example table is not valid."""
 
 
-class ScenarioExamplesNotValidError(ScenarioValidationError):
-    """Scenario steps parameters do not match declared scenario examples."""
-
-
-class FeatureExamplesNotValidError(ScenarioValidationError):
-    """Feature example table is not valid."""
-
-
 class StepDefinitionNotFoundError(Exception):
     """Step definition not found."""
 

--- a/pytest_bdd/hooks.py
+++ b/pytest_bdd/hooks.py
@@ -27,10 +27,6 @@ def pytest_bdd_step_error(request, feature, scenario, step, step_func, step_func
     """Called when step function failed to execute."""
 
 
-def pytest_bdd_step_validation_error(request, feature, scenario, step, step_func, step_func_args, exception):
-    """Called when step failed to validate."""
-
-
 def pytest_bdd_step_func_lookup_error(request, feature, scenario, step, exception):
     """Called when step lookup failed."""
 

--- a/pytest_bdd/parser.py
+++ b/pytest_bdd/parser.py
@@ -234,19 +234,8 @@ class ScenarioTemplate:
         return Scenario(feature=self.feature, name=self.name, line_number=self.line_number, steps=steps, tags=self.tags)
 
     def validate(self):
-        """Validate the scenario.
-
-        :raises ScenarioValidationError: when scenario is not valid
-        """
-        params = frozenset(sum((list(step.params) for step in self.steps), []))
-        example_params = set(self.examples.example_params)
-        if params and example_params and params != example_params:
-            raise exceptions.ScenarioExamplesNotValidError(
-                """Scenario "{}" in the feature "{}" has not valid examples. """
-                """Set of step parameters {} should match set of example values {}.""".format(
-                    self.name, self.feature.filename, sorted(params), sorted(example_params)
-                )
-            )
+        """Validate the scenario."""
+        pass
 
 
 class Scenario:

--- a/pytest_bdd/parser.py
+++ b/pytest_bdd/parser.py
@@ -233,10 +233,6 @@ class ScenarioTemplate:
         ]
         return Scenario(feature=self.feature, name=self.name, line_number=self.line_number, steps=steps, tags=self.tags)
 
-    def validate(self):
-        """Validate the scenario."""
-        pass
-
 
 class Scenario:
 

--- a/pytest_bdd/scenario.py
+++ b/pytest_bdd/scenario.py
@@ -234,9 +234,6 @@ def scenario(feature_name: str, scenario_name: str, encoding: str = "utf-8", fea
             f'Scenario "{scenario_name}" in feature "{feature_name}" in {feature.filename} is not found.'
         )
 
-    # Validate the scenario
-    scenario.validate()
-
     return _get_scenario_decorator(
         feature=feature, feature_name=feature_name, templated_scenario=scenario, scenario_name=scenario_name
     )

--- a/tests/feature/test_outline.py
+++ b/tests/feature/test_outline.py
@@ -87,14 +87,15 @@ def test_wrongly_outlined(testdir):
         outline=textwrap.dedent(
             """\
             Feature: Outline
-                Scenario Outline: Outlined with wrong examples
+                Scenario Outline: Outlined with unused params
                     Given there are <start> cucumbers
                     When I eat <eat> cucumbers
+                    # And commented out step with <unused_param>
                     Then I should have <left> cucumbers
 
                     Examples:
-                    | start | eat | left | unknown_param |
-                    |  12   |  5  |  7   | value         |
+                    | start | eat | left | unused_param |
+                    |  12   |  5  |  7   | value        |
 
             """
         ),
@@ -106,18 +107,14 @@ def test_wrongly_outlined(testdir):
             """\
         from pytest_bdd import scenario
 
-        @scenario("outline.feature", "Outlined with wrong examples")
+        @scenario("outline.feature", "Outlined with unused params")
         def test_outline(request):
             pass
         """
         )
     )
     result = testdir.runpytest()
-    assert_outcomes(result, errors=1)
-    result.stdout.fnmatch_lines(
-        '*ScenarioExamplesNotValidError: Scenario "Outlined with wrong examples"*has not valid examples*',
-    )
-    result.stdout.fnmatch_lines("*should match set of example values [[]'eat', 'left', 'start', 'unknown_param'[]].*")
+    assert_outcomes(result, passed=1)
 
 
 def test_outlined_with_other_fixtures(testdir):

--- a/tests/feature/test_outline.py
+++ b/tests/feature/test_outline.py
@@ -79,7 +79,7 @@ def test_outlined(testdir):
     # fmt: on
 
 
-def test_wrongly_outlined(testdir):
+def test_unused_params(testdir):
     """Test parametrized scenario when the test function lacks parameters."""
 
     testdir.makefile(


### PR DESCRIPTION
The validation doesn't seem to be practical.
Sometimes you just want to comment out a step and reformatting the entire example table is too tedious.