### PR TITLE
Allow "yield" in step definitions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", 3.10.0-rc.2]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
 
     steps:
     - uses: actions/checkout@v2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@
 repos:
 -   repo: https://github.com/psf/black
     # If you update the version here, also update it in tox.ini (py*-pytestlatest-linters)
-    rev: 21.12b0
+    rev: 22.1.0
     hooks:
     - id: black
 -   repo: https://github.com/pycqa/isort
@@ -19,7 +19,7 @@ repos:
     -   id: check-yaml
     -   id: check-added-large-files
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v2.29.1
+    rev: v2.31.0
     hooks:
     -   id: pyupgrade
-        args: [--py36-plus]
+        args: [--py37-plus]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,6 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 -   repo: https://github.com/psf/black
+    # If you update the version here, also update it in tox.ini (py*-pytestlatest-linters)
     rev: 21.12b0
     hooks:
     - id: black

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,7 @@ This release introduces breaking changes in order to be more in line with the of
 - Removed feature level examples for the gherkin compatibility (olegpidsadnyi)
 - Removed vertical examples for the gherkin compatibility (olegpidsadnyi)
 - Step arguments are no longer fixtures (olegpidsadnyi)
+- Step definitions can have "yield" statements again (4.0 release broke it). They will be executed as normal fixtures: code after the yield is executed during teardown of the test. (youtux)
 
 
 

--- a/pytest_bdd/cucumber_json.py
+++ b/pytest_bdd/cucumber_json.py
@@ -61,7 +61,7 @@ class LogBDDCucumberJSON:
             result = {"status": "failed", "error_message": str(report.longrepr) if error_message else ""}
         elif report.skipped:
             result = {"status": "skipped"}
-        result["duration"] = int(math.floor((10 ** 9) * step["duration"]))  # nanosec
+        result["duration"] = int(math.floor((10**9) * step["duration"]))  # nanosec
         return result
 
     def _serialize_tags(self, item):

--- a/pytest_bdd/scenario.py
+++ b/pytest_bdd/scenario.py
@@ -16,7 +16,7 @@ import re
 import typing
 
 import pytest
-from _pytest.fixtures import FixtureLookupError
+from _pytest.fixtures import FixtureLookupError, call_fixture_func
 
 from . import exceptions
 from .feature import get_feature, get_features
@@ -112,8 +112,9 @@ def _execute_step_function(request, scenario, step, step_func):
 
         request.config.hook.pytest_bdd_before_step_call(**kw)
         target_fixture = getattr(step_func, "target_fixture", None)
-        # Execute the step.
-        return_value = step_func(**kwargs)
+
+        # Execute the step as if it was a pytest fixture, so that we can allow "yield" statements in it
+        return_value = call_fixture_func(fixturefunc=step_func, request=request, kwargs=kwargs)
         if target_fixture:
             inject_fixture(request, target_fixture, return_value)
 

--- a/tests/feature/test_steps.py
+++ b/tests/feature/test_steps.py
@@ -484,3 +484,51 @@ def test_step_trace(testdir):
     result.assert_outcomes(failed=1)
     result.stdout.fnmatch_lines(["*test_when_step_validation_error*FAILED"])
     assert "INTERNALERROR" not in result.stdout.str()
+
+
+def test_steps_with_yield(testdir):
+    """Test that steps definition containing a yield statement work the same way as
+    pytest fixture do, that is the code after the yield is executed during teardown."""
+
+    testdir.makefile(
+        ".feature",
+        a="""\
+Feature: A feature
+
+    Scenario: A scenario
+        When I setup stuff
+        Then stuff should be 42
+""",
+    )
+    testdir.makepyfile(
+        textwrap.dedent(
+            """\
+        import pytest
+        from pytest_bdd import given, when, then, scenarios
+
+        scenarios("a.feature")
+
+        @when("I setup stuff", target_fixture="stuff")
+        def stuff():
+            print("Setting up...")
+            yield 42
+            print("Tearing down...")
+
+
+        @then("stuff should be 42")
+        def check_stuff(stuff):
+            assert stuff == 42
+            print("Asserted stuff is 42")
+
+        """
+        )
+    )
+    result = testdir.runpytest("-s")
+    result.assert_outcomes(passed=1)
+    result.stdout.fnmatch_lines(
+        [
+            "*Setting up...*",
+            "*Asserted stuff is 42*",
+            "*Tearing down...*",
+        ]
+    )

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 distshare = {homedir}/.tox/distshare
 envlist = py38-pytestlatest-linters,
-          py39-pytest{43,44,45,46,50,51,52,53,54,60,61,62, latest}-coverage,
+          py39-pytest{43,44,45,46,50,51,52,53,54,60,61,62,70,latest}-coverage,
           py{36,37,38,310}-pytestlatest-coverage,
           py39-pytestlatest-xdist-coverage
 skip_missing_interpreters = true
@@ -12,6 +12,7 @@ setenv =
     xdist: _PYTEST_MORE_ARGS=-n3 -rfsxX
 deps =
     pytestlatest: pytest
+    pytest70: pytest~=7.0.0
     pytest62: pytest~=6.2.0
     pytest61: pytest~=6.1.0
     pytest60: pytest~=6.0.0

--- a/tox.ini
+++ b/tox.ini
@@ -33,7 +33,7 @@ commands = {env:_PYTEST_CMD:pytest} {env:_PYTEST_MORE_ARGS:} {posargs:-vvl}
 
 ; Black doesn't support >py38 now
 [testenv:py38-pytestlatest-linters]
-deps = black
+deps = black==21.12b0
 commands = black --check --verbose setup.py docs pytest_bdd tests
 
 [gh-actions]

--- a/tox.ini
+++ b/tox.ini
@@ -30,9 +30,8 @@ deps =
     -r{toxinidir}/requirements-testing.txt
 commands = {env:_PYTEST_CMD:pytest} {env:_PYTEST_MORE_ARGS:} {posargs:-vvl}
 
-; Black doesn't support >py38 now
 [testenv:py310-pytestlatest-linters]
-deps = black==21.12b0
+deps = black==22.1.0
 commands = black --check --verbose setup.py docs pytest_bdd tests
 
 [gh-actions]


### PR DESCRIPTION
This way step definitions can define code to be executed during teardown of the test item.
Apparently this behaviour was broken by the 4.0 release.

Fixes #392.