### PR TITLE
Don't make steps fixtures

### DIFF
--- a/pytest_bdd/generation.py
+++ b/pytest_bdd/generation.py
@@ -9,7 +9,7 @@ import py
 from mako.lookup import TemplateLookup
 
 from .feature import get_features
-from .scenario import find_argumented_step_fixture_name, make_python_docstring, make_python_name, make_string_literal
+from .scenario import make_python_docstring, make_python_name, make_string_literal
 from .steps import get_step_fixture_name
 from .types import STEP_TYPES
 
@@ -132,6 +132,7 @@ def _find_step_fixturedef(
     if fixturedefs is not None:
         return fixturedefs
 
+    return
     argumented_step_name = find_argumented_step_fixture_name(name, type_, fixturemanager)
     if argumented_step_name is not None:
         return fixturemanager.getfixturedefs(argumented_step_name, item.nodeid)

--- a/pytest_bdd/parsers.py
+++ b/pytest_bdd/parsers.py
@@ -104,5 +104,3 @@ def get_parser(step_name: Any) -> StepParser:
 
     if isinstance(step_name, StepParser):
         return step_name
-
-    return string(step_name)

--- a/pytest_bdd/scenario.py
+++ b/pytest_bdd/scenario.py
@@ -22,7 +22,7 @@ from _pytest.fixtures import FixtureRequest, call_fixture_func
 
 from . import exceptions
 from .feature import get_feature, get_features
-from .steps import inject_fixture, registry, parser_registry
+from .steps import inject_fixture, parser_registry, registry
 from .utils import CONFIG_STACK, get_args, get_caller_module_locals, get_caller_module_path
 
 if TYPE_CHECKING:


### PR DESCRIPTION
This is an attempt at removing how steps are registered via fixtures,
and instead use a custom registry. It seems that using fixtures for that
is a bit awkward, as we can't differentiate steps from regular fixtures
apart from the parser attribute, and we need to access private pytest
attributes to do so. Given that pytest_bdd both produces and consumes
the steps, it would seem that we can remove it. As an added bonus it
should have a minor performance increase.

This is mostly a proof of concept, as I wanted to start the discussion.
Let me know if it doesn't make sense, thanks.