### PR TITLE
Fix missing step parameter substitution

### DIFF
--- a/pytest_bdd/parser.py
+++ b/pytest_bdd/parser.py
@@ -334,7 +334,10 @@ class Step:
     def render(self, context: Mapping[str, Any]):
         def replacer(m: Match):
             varname = m.group(1)
-            return str(context[varname])
+            try:
+                return str(context[varname])
+            except KeyError:
+                return f"<{varname}>"
 
         return STEP_PARAM_RE.sub(replacer, self.name)
 

--- a/tests/feature/test_steps.py
+++ b/tests/feature/test_steps.py
@@ -532,3 +532,36 @@ Feature: A feature
             "*Tearing down...*",
         ]
     )
+
+
+def test_missing_substitution_steps(testdir):
+    testdir.makefile(
+        ".feature",
+        steps=textwrap.dedent(
+            """\
+            Feature: Missing substitutions are left as is
+
+                Scenario: Missing substitution
+                    Given Missing <substitution>
+            """
+        ),
+    )
+
+    testdir.makepyfile(
+        textwrap.dedent(
+            """\
+        from pytest_bdd import given, when, then, scenario
+
+        @scenario("steps.feature", "Missing substitution")
+        def test_steps():
+            pass
+
+        @given('Missing <substitution>')
+        def foo():
+            pass
+
+        """
+        )
+    )
+    result = testdir.runpytest()
+    result.assert_outcomes(passed=1, failed=0)


### PR DESCRIPTION
This defect blocks allure-pytest-bdd plugin to work with pytest>5.0

https://github.com/allure-framework/allure-python/pull/660