### PR TITLE
Allow the user to specify the `caller_locals` for step and scenarios decorators

### DIFF
--- a/pytest_bdd/scenario.py
+++ b/pytest_bdd/scenario.py
@@ -263,12 +263,13 @@ def get_python_name_generator(name: str) -> Iterable[str]:
         suffix = f"_{index}"
 
 
-def scenarios(*feature_paths: str, **kwargs: Any) -> None:
+def scenarios(*feature_paths: str, caller_locals: dict[str, object] | None = None, **kwargs: Any) -> None:
     """Parse features from the paths and put all found scenarios in the caller module.
 
     :param *feature_paths: feature file paths to use for scenarios
     """
-    caller_locals = get_caller_module_locals()
+    if caller_locals is None:
+        caller_locals = get_caller_module_locals()
     caller_path = get_caller_module_path()
 
     features_base_dir = kwargs.get("features_base_dir")

--- a/pytest_bdd/steps.py
+++ b/pytest_bdd/steps.py
@@ -75,6 +75,7 @@ def given(
     name: str | StepParser,
     converters: dict[str, Callable] | None = None,
     target_fixture: str | None = None,
+    caller_locals: dict[str, object] | None = None,
 ) -> Callable:
     """Given step decorator.
 
@@ -85,11 +86,18 @@ def given(
 
     :return: Decorator function for the step.
     """
-    return _step_decorator(GIVEN, name, converters=converters, target_fixture=target_fixture)
+    if caller_locals is None:
+        caller_locals = get_caller_module_locals()
+    return _step_decorator(
+        GIVEN, name, converters=converters, target_fixture=target_fixture, caller_locals=caller_locals
+    )
 
 
 def when(
-    name: str | StepParser, converters: dict[str, Callable] | None = None, target_fixture: str | None = None
+    name: str | StepParser,
+    converters: dict[str, Callable] | None = None,
+    target_fixture: str | None = None,
+    caller_locals: dict[str, object] | None = None,
 ) -> Callable:
     """When step decorator.
 
@@ -100,11 +108,18 @@ def when(
 
     :return: Decorator function for the step.
     """
-    return _step_decorator(WHEN, name, converters=converters, target_fixture=target_fixture)
+    if caller_locals is None:
+        caller_locals = get_caller_module_locals()
+    return _step_decorator(
+        WHEN, name, converters=converters, target_fixture=target_fixture, caller_locals=caller_locals
+    )
 
 
 def then(
-    name: str | StepParser, converters: dict[str, Callable] | None = None, target_fixture: str | None = None
+    name: str | StepParser,
+    converters: dict[str, Callable] | None = None,
+    target_fixture: str | None = None,
+    caller_locals: dict[str, object] | None = None,
 ) -> Callable:
     """Then step decorator.
 
@@ -115,12 +130,17 @@ def then(
 
     :return: Decorator function for the step.
     """
-    return _step_decorator(THEN, name, converters=converters, target_fixture=target_fixture)
+    if caller_locals is None:
+        caller_locals = get_caller_module_locals()
+    return _step_decorator(
+        THEN, name, converters=converters, target_fixture=target_fixture, caller_locals=caller_locals
+    )
 
 
 def _step_decorator(
     step_type: Literal["given", "when", "then"],
     step_name: str | StepParser,
+    caller_locals: dict[str, object],
     converters: dict[str, Callable] | None = None,
     target_fixture: str | None = None,
 ) -> Callable:
@@ -135,6 +155,9 @@ def _step_decorator(
     """
     if converters is None:
         converters = {}
+
+    if caller_locals is None:
+        caller_locals = get_caller_module_locals()
 
     def decorator(func: TCallable) -> TCallable:
         parser = get_parser(step_name)
@@ -154,7 +177,6 @@ def _step_decorator(
             target_fixture=target_fixture,
         )
 
-        caller_locals = get_caller_module_locals()
         caller_locals[fixture_step_name] = pytest.fixture(name=fixture_step_name)(step_function_marker)
         return func
 

--- a/pytest_bdd/steps.py
+++ b/pytest_bdd/steps.py
@@ -156,9 +156,6 @@ def _step_decorator(
     if converters is None:
         converters = {}
 
-    if caller_locals is None:
-        caller_locals = get_caller_module_locals()
-
     def decorator(func: TCallable) -> TCallable:
         parser = get_parser(step_name)
         parsed_step_name = parser.name

--- a/tests/args/test_common.py
+++ b/tests/args/test_common.py
@@ -27,7 +27,6 @@ def test_reuse_same_step_different_converters(testdir):
         from pytest_bdd.utils import dump_obj
 
         scenarios("arguments.feature")
-
         @given(parsers.re(r"^I have a foo with int value (?P<value>.*?)$"), converters={"value": int})
         @given(parsers.re(r"^I have a foo with str value (?P<value>.*?)$"), converters={"value": str})
         @given(parsers.re(r"^I have a foo with float value (?P<value>.*?)$"), converters={"value": float})


### PR DESCRIPTION
Some users need it for advanced use cases.

Checklist:

- [x] Create tests