### PR TITLE
Use modern approach to specify hook options

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,7 +7,7 @@ Unreleased
 - Step functions can now be decorated multiple times with @given, @when, @then. Previously every decorator would override ``converters`` and ``target_fixture`` every at every application. `#534 <https://github.com/pytest-dev/pytest-bdd/pull/534>`_ `#544 <https://github.com/pytest-dev/pytest-bdd/pull/544>`_ `#525 <https://github.com/pytest-dev/pytest-bdd/issues/525>`_
 - ``parsers.re`` now does a `fullmatch <https://docs.python.org/3/library/re.html#re.fullmatch>`_ instead of a partial match. This is to make it work just like the other parsers, since they don't ignore non-matching characters at the end of the string. `#539 <https://github.com/pytest-dev/pytest-bdd/pull/539>`_
 - Require pytest>=6.2 `#534 <https://github.com/pytest-dev/pytest-bdd/pull/534>`_
-
+- Using modern way to specify hook options to avoid deprecation warnings with pytest >=7.2.
 
 6.0.1
 -----

--- a/pytest_bdd/plugin.py
+++ b/pytest_bdd/plugin.py
@@ -62,7 +62,7 @@ def add_bdd_ini(parser: Parser) -> None:
     parser.addini("bdd_features_base_dir", "Base features directory.")
 
 
-@pytest.mark.trylast
+@pytest.hookimpl(trylast=True)
 def pytest_configure(config: Config) -> None:
     """Configure all subplugins."""
     CONFIG_STACK.append(config)
@@ -76,18 +76,18 @@ def pytest_unconfigure(config: Config) -> None:
     cucumber_json.unconfigure(config)
 
 
-@pytest.mark.hookwrapper
+@pytest.hookimpl(hookwrapper=True)
 def pytest_runtest_makereport(item: Item, call: CallInfo) -> Generator[None, _Result, None]:
     outcome = yield
     reporting.runtest_makereport(item, call, outcome.get_result())
 
 
-@pytest.mark.tryfirst
+@pytest.hookimpl(tryfirst=True)
 def pytest_bdd_before_scenario(request: FixtureRequest, feature: Feature, scenario: Scenario) -> None:
     reporting.before_scenario(request, feature, scenario)
 
 
-@pytest.mark.tryfirst
+@pytest.hookimpl(tryfirst=True)
 def pytest_bdd_step_error(
     request: FixtureRequest,
     feature: Feature,
@@ -100,14 +100,14 @@ def pytest_bdd_step_error(
     reporting.step_error(request, feature, scenario, step, step_func, step_func_args, exception)
 
 
-@pytest.mark.tryfirst
+@pytest.hookimpl(tryfirst=True)
 def pytest_bdd_before_step(
     request: FixtureRequest, feature: Feature, scenario: Scenario, step: Step, step_func: Callable
 ) -> None:
     reporting.before_step(request, feature, scenario, step, step_func)
 
 
-@pytest.mark.tryfirst
+@pytest.hookimpl(tryfirst=True)
 def pytest_bdd_after_step(
     request: FixtureRequest,
     feature: Feature,


### PR DESCRIPTION
The old way using marks is being deprecated in pytest 7.2:

https://github.com/pytest-dev/pytest/pull/9118