### PR TITLE
hide pytest-bdd internal method in user tracebacks

### DIFF
--- a/src/pytest_bdd/feature.py
+++ b/src/pytest_bdd/feature.py
@@ -48,7 +48,7 @@ def get_feature(base_path: str, filename: str, encoding: str = "utf-8") -> Featu
            stored in the global variable cache to improve the performance
            when multiple scenarios are referencing the same file.
     """
-
+    __tracebackhide__ = True
     full_name = os.path.abspath(os.path.join(base_path, filename))
     feature = features.get(full_name)
     if not feature:

--- a/src/pytest_bdd/parser.py
+++ b/src/pytest_bdd/parser.py
@@ -88,6 +88,7 @@ def parse_feature(basedir: str, filename: str, encoding: str = "utf-8") -> Featu
     :param str filename: Relative path to the feature file.
     :param str encoding: Feature file encoding (utf-8 by default).
     """
+    __tracebackhide__ = True
     abs_filename = os.path.abspath(os.path.join(basedir, filename))
     rel_filename = os.path.join(os.path.basename(basedir), filename)
     feature = Feature(

--- a/src/pytest_bdd/scenario.py
+++ b/src/pytest_bdd/scenario.py
@@ -110,6 +110,7 @@ def get_step_function(request, step: Step) -> StepFunctionContext | None:
 
     Finally we let request.getfixturevalue(...) fetch the step definition fixture.
     """
+    __tracebackhide__ = True
     bdd_name = get_step_fixture_name(step=step)
 
     with inject_fixturedefs_for_step(step=step, fixturemanager=request._fixturemanager, nodeid=request.node.nodeid):
@@ -123,6 +124,7 @@ def _execute_step_function(
     request: FixtureRequest, scenario: Scenario, step: Step, context: StepFunctionContext
 ) -> None:
     """Execute step function."""
+    __tracebackhide__ = True
     kw = {
         "request": request,
         "feature": scenario.feature,
@@ -173,6 +175,7 @@ def _execute_scenario(feature: Feature, scenario: Scenario, request: FixtureRequ
     :param request: request.
     :param encoding: Encoding.
     """
+    __tracebackhide__ = True
     request.config.hook.pytest_bdd_before_scenario(request=request, feature=feature, scenario=scenario)
 
     for step in scenario.steps:
@@ -214,6 +217,7 @@ def _get_scenario_decorator(
         # otherwise indirect fixtures would not work.
         @pytest.mark.usefixtures(*func_args)
         def scenario_wrapper(request: FixtureRequest, _pytest_bdd_example: dict[str, str]) -> Any:
+            __tracebackhide__ = True
             scenario = templated_scenario.render(_pytest_bdd_example)
             _execute_scenario(feature, scenario, request)
             fixture_values = [request.getfixturevalue(arg) for arg in func_args]
@@ -259,7 +263,7 @@ def scenario(
     :param str scenario_name: Scenario name.
     :param str encoding: Feature file encoding.
     """
-
+    __tracebackhide__ = True
     scenario_name = str(scenario_name)
     caller_module_path = get_caller_module_path()
 


### PR DESCRIPTION
hide pytest-bdd internal method in user tracebacks.

It makes a much tidier output, a bit like when not using pytest-bdd:

```
__________________________________________________________________ test_authenticated_access_to_the_application ___________________________________________________________________
.venv/lib/python3.10/site-packages/pytest_bdd/scenario.py:184: in scenario_wrapper
    _execute_scenario(feature, scenario, request)
.venv/lib/python3.10/site-packages/pytest_bdd/scenario.py:154: in _execute_scenario
    _execute_step_function(request, scenario, step, step_func)
.venv/lib/python3.10/site-packages/pytest_bdd/scenario.py:124: in _execute_step_function
    return_value = call_fixture_func(fixturefunc=step_func, request=request, kwargs=kwargs)
.venv/lib/python3.10/site-packages/_pytest/fixtures.py:891: in call_fixture_func
    fixture_result = fixturefunc(**kwargs)
tests/gui/step_defs/star_steps.py:36: in redirected_to_homepage
    assert False
E   AssertionError
```

becomes just:

```
__________________________________________________________________ test_authenticated_access_to_the_application ___________________________________________________________________
tests/gui/step_defs/star_steps.py:36: in redirected_to_homepage
    assert False
E   AssertionError
```

I tried to hide only the methods that I've actually seen in my errors, but a more complete approach may be chosen.

fixes #555 