### PR TITLE
Drop dependency on glob2

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -18,7 +18,7 @@ python-versions = ">=3.5"
 dev = ["cloudpickle", "coverage[toml] (>=5.0.2)", "furo", "hypothesis", "mypy (>=0.900,!=0.940)", "pre-commit", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "sphinx", "sphinx-notfound-page", "zope.interface"]
 docs = ["furo", "sphinx", "sphinx-notfound-page", "zope.interface"]
 tests = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy (>=0.900,!=0.940)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "zope.interface"]
-tests_no_zope = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy (>=0.900,!=0.940)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins"]
+tests-no-zope = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy (>=0.900,!=0.940)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins"]
 
 [[package]]
 name = "colorama"
@@ -72,14 +72,6 @@ python-versions = ">=3.7"
 [package.extras]
 docs = ["furo (>=2022.6.21)", "sphinx (>=5.1.1)", "sphinx-autodoc-typehints (>=1.19.1)"]
 testing = ["covdefaults (>=2.2)", "coverage (>=6.4.2)", "pytest (>=7.1.2)", "pytest-cov (>=3)", "pytest-timeout (>=2.1)"]
-
-[[package]]
-name = "glob2"
-version = "0.7"
-description = "Version of the glob module that can capture patterns and supports recursive wildcards"
-category = "main"
-optional = false
-python-versions = "*"
 
 [[package]]
 name = "importlib-metadata"
@@ -403,7 +395,7 @@ testing = ["func-timeout", "jaraco.itertools", "pytest (>=6)", "pytest-black (>=
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "f8d199095c9f4627a22a8a7b6804d0b95fa623b40dafd7dca7615c3e4fef9b34"
+content-hash = "7fb205495f6c4afbc88e8bab9549eb2e320de9f3b3b720d5ef06cd4a6c4c5f82"
 
 [metadata.files]
 atomicwrites = [
@@ -471,9 +463,6 @@ execnet = [
 filelock = [
     {file = "filelock-3.8.0-py3-none-any.whl", hash = "sha256:617eb4e5eedc82fc5f47b6d61e4d11cb837c56cb4544e39081099fa17ad109d4"},
     {file = "filelock-3.8.0.tar.gz", hash = "sha256:55447caa666f2198c5b6b13a26d2084d26fa5b115c00d065664b2124680c4edc"},
-]
-glob2 = [
-    {file = "glob2-0.7.tar.gz", hash = "sha256:85c3dbd07c8aa26d63d7aacee34fa86e9a91a3873bc30bf62ec46e531f92ab8c"},
 ]
 importlib-metadata = [
     {file = "importlib_metadata-4.12.0-py3-none-any.whl", hash = "sha256:7401a975809ea1fdc658c3aa4f78cc2195a0e019c5cbc4c06122884e9ae80c23"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,6 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.7"
-glob2 = "*"
 Mako = "*"
 parse = "*"
 parse-type = "*"
@@ -83,5 +82,5 @@ warn_unused_configs = true
 files = "src/pytest_bdd/**/*.py"
 
 [[tool.mypy.overrides]]
-module = ["parse", "parse_type", "glob2"]
+module = ["parse", "parse_type"]
 ignore_missing_imports = true

--- a/src/pytest_bdd/feature.py
+++ b/src/pytest_bdd/feature.py
@@ -25,9 +25,8 @@ one line.
 """
 from __future__ import annotations
 
+import glob
 import os.path
-
-import glob2
 
 from .parser import Feature, parse_feature
 
@@ -70,7 +69,9 @@ def get_features(paths: list[str], **kwargs) -> list[Feature]:
         if path not in seen_names:
             seen_names.add(path)
             if os.path.isdir(path):
-                features.extend(get_features(glob2.iglob(os.path.join(path, "**", "*.feature")), **kwargs))
+                features.extend(
+                    get_features(glob.iglob(os.path.join(path, "**", "*.feature"), recursive=True), **kwargs)
+                )
             else:
                 base, name = os.path.split(path)
                 feature = get_feature(base, name, **kwargs)

--- a/src/pytest_bdd/scripts.py
+++ b/src/pytest_bdd/scripts.py
@@ -2,10 +2,9 @@
 from __future__ import annotations
 
 import argparse
+import glob
 import os.path
 import re
-
-import glob2
 
 from .generation import generate_code, parse_feature_files
 
@@ -15,7 +14,7 @@ MIGRATE_REGEX = re.compile(r"\s?(\w+)\s=\sscenario\((.+)\)", flags=re.MULTILINE)
 def migrate_tests(args: argparse.Namespace) -> None:
     """Migrate outdated tests to the most recent form."""
     path = args.path
-    for file_path in glob2.iglob(os.path.join(os.path.abspath(path), "**", "*.py")):
+    for file_path in glob.iglob(os.path.join(os.path.abspath(path), "**", "*.py"), recursive=True):
         migrate_tests_in_file(file_path)
 
 


### PR DESCRIPTION
The standard library's `glob` supports "**" since Python 3.5. pytest-bdd requires Python >= 3.7.

TODO:

- [x] Merge #571 and rebase.