### PR TITLE
Drop dependency on py.io

### DIFF
--- a/src/pytest_bdd/generation.py
+++ b/src/pytest_bdd/generation.py
@@ -5,8 +5,12 @@ import itertools
 import os.path
 from typing import TYPE_CHECKING, cast
 
-import py
 from mako.lookup import TemplateLookup
+
+try:
+    from _pytest._io import TerminalWriter
+except ImportError:
+    from py.io import TerminalWriter
 
 from .feature import get_features
 from .scenario import inject_fixturedefs_for_step, make_python_docstring, make_python_name, make_string_literal
@@ -79,7 +83,7 @@ def show_missing_code(config: Config) -> int:
 
 def print_missing_code(scenarios: list[ScenarioTemplate], steps: list[Step]) -> None:
     """Print missing code with TerminalWriter."""
-    tw = py.io.TerminalWriter()
+    tw = TerminalWriter()
     scenario = step = None
 
     for scenario in scenarios:
@@ -166,7 +170,7 @@ def group_steps(steps: list[Step]) -> list[Step]:
 
 def _show_missing_code_main(config: Config, session: Session) -> None:
     """Preparing fixture duplicates for output."""
-    tw = py.io.TerminalWriter()
+    tw = TerminalWriter()
     session.perform_collect()
 
     fm = session._fixturemanager

--- a/src/pytest_bdd/generation.py
+++ b/src/pytest_bdd/generation.py
@@ -5,12 +5,8 @@ import itertools
 import os.path
 from typing import TYPE_CHECKING, cast
 
+from _pytest._io import TerminalWriter
 from mako.lookup import TemplateLookup
-
-try:
-    from _pytest._io import TerminalWriter
-except ImportError:
-    from py.io import TerminalWriter
 
 from .feature import get_features
 from .scenario import inject_fixturedefs_for_step, make_python_docstring, make_python_name, make_string_literal

--- a/tox.ini
+++ b/tox.ini
@@ -15,13 +15,6 @@ deps =
     pytest71: pytest~=7.1.0
     pytest70: pytest~=7.0.0
     pytest62: pytest~=6.2.0
-    pytest61: pytest~=6.1.0
-    pytest60: pytest~=6.0.0
-    pytest54: pytest~=5.4.0
-    pytest53: pytest~=5.3.0
-    pytest52: pytest~=5.2.0
-    pytest51: pytest~=5.1.0
-    pytest50: pytest~=5.0.0
 
     coverage: coverage[toml]
     xdist: pytest-xdist


### PR DESCRIPTION
Since pytest 7.2.0 was released 2 weeks ago (2022-10-23), CI fails against `pytest-latest`:

    INTERNALERROR>     tw = py.io.TerminalWriter()
    INTERNALERROR> AttributeError: module 'py' has no attribute 'io'

Pytest 7.2.0 dropped its dependency on the `py` package. We don't specify `py` explicitly as a dependency, so tests starting failing since the release of pytest 7.2.0.

To drop this dependency, pytest vendored `py.io.TerminalWriter` into `_pytest._io` in pytest commit [276405a03] (6.0.0rc1). We require pytest>=6.2, so we can import it from there.

[276405a03]: https://github.com/pytest-dev/pytest/commit/276405a03