### PR TITLE
Multiline and example tags

### DIFF
--- a/src/pytest_bdd/parser.py
+++ b/src/pytest_bdd/parser.py
@@ -378,11 +378,11 @@ def get_tags(all_lines: list[str] | str | None, line_number: int = 0) -> set[str
 
     total_tags = set[str]
     line_offset = 2  # Used to denote the line containing the tags, above the current line
-    if not all_lines[line_number-line_offset] or not all_lines[line_number-line_offset].strip().startswith("@"):
+    if not all_lines[line_number - line_offset] or not all_lines[line_number - line_offset].strip().startswith("@"):
         return set()
     else:
-        while (line_number - 1) > 0 and all_lines[line_number-line_offset].strip().startswith("@"):
-            line_tags = {tag.lstrip("@") for tag in all_lines[line_number-2].strip().split(" @") if len(tag) > 1}
+        while (line_number - 1) > 0 and all_lines[line_number - line_offset].strip().startswith("@"):
+            line_tags = {tag.lstrip("@") for tag in all_lines[line_number - 2].strip().split(" @") if len(tag) > 1}
             total_tags = total_tags.union(line_tags)
             line_number -= 1
         return total_tags

--- a/src/pytest_bdd/parser.py
+++ b/src/pytest_bdd/parser.py
@@ -141,7 +141,6 @@ def parse_feature(basedir: str, filename: str, encoding: str = "utf-8") -> Featu
                 _, feature.name = parse_line(clean_line)
                 feature.line_number = line_number
                 feature.tags = get_tags(all_lines, line_number)
-
             elif prev_mode == types.FEATURE:
                 description.append(clean_line)
             else:
@@ -364,19 +363,25 @@ class Examples:
         return bool(self.examples)
 
 
-def get_tags(all_lines: list[str] | None, line_number: int) -> set[str]:
+def get_tags(all_lines: list[str] | str | None, line_number: int = 0) -> set[str]:
     """Get tags out of the given line.
 
     :param str line: Feature file text line.
+    :param int line_number: Starting line.
 
     :return: List of tags.
     """
+    if isinstance(all_lines, str) or not all_lines:
+        if not all_lines or not all_lines.strip().startswith("@"):
+            return set()
+        return {tag.lstrip("@") for tag in all_lines.strip().split(" @") if len(tag) > 1}
+
     total_tags = set[str]
-   
-    if not all_lines[line_number-2] or not all_lines[line_number-2].strip().startswith("@"):
+    line_offset = 2  # Used to denote the line containing the tags, above the current line
+    if not all_lines[line_number-line_offset] or not all_lines[line_number-line_offset].strip().startswith("@"):
         return set()
     else:
-        while (line_number - 1) > 0 and all_lines[line_number-2].strip().startswith("@"):
+        while (line_number - 1) > 0 and all_lines[line_number-line_offset].strip().startswith("@"):
             line_tags = {tag.lstrip("@") for tag in all_lines[line_number-2].strip().split(" @") if len(tag) > 1}
             total_tags = total_tags.union(line_tags)
             line_number -= 1

--- a/src/pytest_bdd/scenario.py
+++ b/src/pytest_bdd/scenario.py
@@ -243,14 +243,17 @@ def _get_scenario_decorator(
 
 def collect_example_parametrizations(
     templated_scenario: ScenarioTemplate,
-) -> list[ParameterSet] | None:
+) -> tuple[list[ParameterSet], set[str]] | None:
     # We need to evaluate these iterators and store them as lists, otherwise
     # we won't be able to do the cartesian product later (the second iterator will be consumed)
     contexts = list(templated_scenario.examples.as_contexts())
     if not contexts:
         return None
+    return [pytest.param(context[0], id="-".join(context[0].values()), marks=_register_tags_as_marks(context[1])) for context in contexts]
 
-    return [pytest.param(context, id="-".join(context.values())) for context in contexts]
+
+def _register_tags_as_marks(tags) -> list[pytest.mark]:
+    return [getattr(pytest.mark, marks) for marks in tags]
 
 
 def scenario(

--- a/src/pytest_bdd/scenario.py
+++ b/src/pytest_bdd/scenario.py
@@ -249,7 +249,10 @@ def collect_example_parametrizations(
     contexts = list(templated_scenario.examples.as_contexts())
     if not contexts:
         return None
-    return [pytest.param(context[0], id="-".join(context[0].values()), marks=_register_tags_as_marks(context[1])) for context in contexts]
+    return [
+        pytest.param(context[0], id="-".join(context[0].values()), marks=_register_tags_as_marks(context[1]))
+        for context in contexts
+    ]
 
 
 def _register_tags_as_marks(tags) -> list[pytest.mark]:

--- a/tests/feature/test_tags.py
+++ b/tests/feature/test_tags.py
@@ -66,6 +66,7 @@ def test_tags_selector(pytester):
     result = pytester.runpytest("-m", "feature_tag_10", "-vv").parseoutcomes()
     assert result["deselected"] == 2
 
+
 def test_multiline_tags(pytester):
     """Test tests selection by multiline tags."""
     pytester.makefile(
@@ -87,7 +88,7 @@ def test_multiline_tags(pytester):
     pytester.makefile(
         ".feature",
         test="""
-    @feature_tag_1 
+    @feature_tag_1
     @feature_tag_2
     Feature: Tags
 
@@ -95,7 +96,7 @@ def test_multiline_tags(pytester):
     Scenario: Tags
         Given I have a bar
 
-    @scenario_tag_10 
+    @scenario_tag_10
     @scenario_tag_20
     @scenario_tag_30
     Scenario: Tags 2
@@ -228,7 +229,7 @@ def test_example_tags(pytester):
 
     result = pytester.runpytest("-m", "feature_tag_1", "-vv").parseoutcomes()
     assert result["passed"] == 2
-    
+
     result = pytester.runpytest("-m", "feature_tag_1 and not example_tag_02", "-vv").parseoutcomes()
     assert result["passed"] == 1
     assert result["deselected"] == 1


### PR DESCRIPTION
I've added support for multiline tags and tags on examples.
This is to follow parity of what is supported by cucumber's tagging implementation.

Let me know if more unit tests are required.