### PR TITLE
Peo 7674 add datatables

### DIFF
--- a/src/pytest_bdd/parser.py
+++ b/src/pytest_bdd/parser.py
@@ -141,7 +141,6 @@ def parse_feature(basedir: str, filename: str, encoding: str = "utf-8") -> Featu
                 _, feature.name = parse_line(clean_line)
                 feature.line_number = line_number
                 feature.tags = get_tags(all_lines, line_number)
-
             elif prev_mode == types.FEATURE:
                 description.append(clean_line)
             else:
@@ -364,19 +363,25 @@ class Examples:
         return bool(self.examples)
 
 
-def get_tags(all_lines: list[str] | None, line_number: int) -> set[str]:
+def get_tags(all_lines: list[str] | str | None, line_number: int = 0) -> set[str]:
     """Get tags out of the given line.
 
     :param str line: Feature file text line.
+    :param int line_number: Starting line.
 
     :return: List of tags.
     """
+    if isinstance(all_lines, str) or not all_lines:
+        if not all_lines or not all_lines.strip().startswith("@"):
+            return set()
+        return {tag.lstrip("@") for tag in all_lines.strip().split(" @") if len(tag) > 1}
+
     total_tags = set[str]
-   
-    if not all_lines[line_number-2] or not all_lines[line_number-2].strip().startswith("@"):
+    line_offset = 2  # Used to denote the line containing the tags, above the current line
+    if not all_lines[line_number-line_offset] or not all_lines[line_number-line_offset].strip().startswith("@"):
         return set()
     else:
-        while (line_number - 1) > 0 and all_lines[line_number-2].strip().startswith("@"):
+        while (line_number - 1) > 0 and all_lines[line_number-line_offset].strip().startswith("@"):
             line_tags = {tag.lstrip("@") for tag in all_lines[line_number-2].strip().split(" @") if len(tag) > 1}
             total_tags = total_tags.union(line_tags)
             line_number -= 1

--- a/src/pytest_bdd/parser.py
+++ b/src/pytest_bdd/parser.py
@@ -264,6 +264,7 @@ class Step:
     scenario: ScenarioTemplate | None = field(init=False, default=None)
     background: Background | None = field(init=False, default=None)
     lines: list[str] = field(init=False, default_factory=list)
+    datatable: list[str] = None
 
     def __init__(self, name: str, type: str, indent: int, line_number: int, keyword: str) -> None:
         self.name = name
@@ -276,13 +277,19 @@ class Step:
         self.scenario = None
         self.background = None
         self.lines = []
+        self.datatable = []
 
     def add_line(self, line: str) -> None:
-        """Add line to the multiple step.
+        """Add line to the multiple step or add a line to the datatable.
 
-        :param str line: Line of text - the continuation of the step name.
+        :param str line: Line of text - the continuation of the step name or a datatable row.
         """
-        self.lines.append(line)
+        if(line.startswith("|") and line.endswith("|")):
+            # datatable line
+            line = line[1:-1]
+            self.datatable.append(line.split("|"))
+        else:
+            self.lines.append(line)
 
     @property
     def name(self) -> str:

--- a/src/pytest_bdd/parser.py
+++ b/src/pytest_bdd/parser.py
@@ -51,7 +51,7 @@ def parse_line(line: str) -> tuple[str, str]:
     """
     for prefix, _ in STEP_PREFIXES:
         if line.startswith(prefix):
-            return prefix.strip(), line[len(prefix) :].strip()
+            return prefix.strip(), line[len(prefix):].strip()
     return "", line
 
 
@@ -167,18 +167,22 @@ def parse_feature(basedir: str, filename: str, encoding: str = "utf-8") -> Featu
             )
             feature.scenarios[parsed_line] = scenario
         elif mode == types.BACKGROUND:
-            feature.background = Background(feature=feature, line_number=line_number)
+            feature.background = Background(
+                feature=feature, line_number=line_number)
         elif mode == types.EXAMPLES:
             mode = types.EXAMPLES_HEADERS
             scenario.examples.line_number = line_number
             scenario.examples.tags = get_tags(all_lines, line_number)
         elif mode == types.EXAMPLES_HEADERS:
-            scenario.examples.set_param_names([l for l in split_line(parsed_line) if l])
+            scenario.examples.set_param_names(
+                [l for l in split_line(parsed_line) if l])
             mode = types.EXAMPLE_LINE
         elif mode == types.EXAMPLE_LINE:
-            scenario.examples.add_example([l for l in split_line(stripped_line)])
+            scenario.examples.add_example(
+                [l for l in split_line(stripped_line)])
         elif mode and mode not in (types.FEATURE, types.TAG):
-            step = Step(name=parsed_line, type=mode, indent=line_indent, line_number=line_number, keyword=keyword)
+            step = Step(name=parsed_line, type=mode, indent=line_indent,
+                        line_number=line_number, keyword=keyword)
             if feature.background and not scenario:
                 feature.background.add_step(step)
             else:
@@ -264,7 +268,7 @@ class Step:
     scenario: ScenarioTemplate | None = field(init=False, default=None)
     background: Background | None = field(init=False, default=None)
     lines: list[str] = field(init=False, default_factory=list)
-    datatable: list[str] = None
+    datatable: list[str] = field(init=False, default_factory=list)
 
     def __init__(self, name: str, type: str, indent: int, line_number: int, keyword: str) -> None:
         self.name = name
@@ -284,16 +288,18 @@ class Step:
 
         :param str line: Line of text - the continuation of the step name or a datatable row.
         """
-        if(line.startswith("|") and line.endswith("|")):
+        clean_line = line.strip()
+        if (clean_line.startswith("|") and clean_line.endswith("|")):
             # datatable line
-            line = line[1:-1]
-            self.datatable.append(line.split("|"))
+            clean_line = clean_line[1:-1]
+            self.datatable.append(clean_line.split("|"))
         else:
             self.lines.append(line)
 
     @property
     def name(self) -> str:
-        multilines_content = textwrap.dedent("\n".join(self.lines)) if self.lines else ""
+        multilines_content = textwrap.dedent(
+            "\n".join(self.lines)) if self.lines else ""
 
         # Remove the multiline quotes, if present.
         multilines_content = re.sub(
@@ -389,7 +395,8 @@ def get_tags(all_lines: list[str] | str | None, line_number: int = 0) -> set[str
         return set()
     else:
         while (line_number - 1) > 0 and all_lines[line_number-line_offset].strip().startswith("@"):
-            line_tags = {tag.lstrip("@") for tag in all_lines[line_number-2].strip().split(" @") if len(tag) > 1}
+            line_tags = {tag.lstrip(
+                "@") for tag in all_lines[line_number-2].strip().split(" @") if len(tag) > 1}
             total_tags = total_tags.union(line_tags)
             line_number -= 1
         return total_tags

--- a/src/pytest_bdd/parser.py
+++ b/src/pytest_bdd/parser.py
@@ -51,7 +51,7 @@ def parse_line(line: str) -> tuple[str, str]:
     """
     for prefix, _ in STEP_PREFIXES:
         if line.startswith(prefix):
-            return prefix.strip(), line[len(prefix):].strip()
+            return prefix.strip(), line[len(prefix) :].strip()
     return "", line
 
 
@@ -167,22 +167,18 @@ def parse_feature(basedir: str, filename: str, encoding: str = "utf-8") -> Featu
             )
             feature.scenarios[parsed_line] = scenario
         elif mode == types.BACKGROUND:
-            feature.background = Background(
-                feature=feature, line_number=line_number)
+            feature.background = Background(feature=feature, line_number=line_number)
         elif mode == types.EXAMPLES:
             mode = types.EXAMPLES_HEADERS
             scenario.examples.line_number = line_number
             scenario.examples.tags = get_tags(all_lines, line_number)
         elif mode == types.EXAMPLES_HEADERS:
-            scenario.examples.set_param_names(
-                [l for l in split_line(parsed_line) if l])
+            scenario.examples.set_param_names([l for l in split_line(parsed_line) if l])
             mode = types.EXAMPLE_LINE
         elif mode == types.EXAMPLE_LINE:
-            scenario.examples.add_example(
-                [l for l in split_line(stripped_line)])
+            scenario.examples.add_example([l for l in split_line(stripped_line)])
         elif mode and mode not in (types.FEATURE, types.TAG):
-            step = Step(name=parsed_line, type=mode, indent=line_indent,
-                        line_number=line_number, keyword=keyword)
+            step = Step(name=parsed_line, type=mode, indent=line_indent, line_number=line_number, keyword=keyword)
             if feature.background and not scenario:
                 feature.background.add_step(step)
             else:
@@ -289,7 +285,7 @@ class Step:
         :param str line: Line of text - the continuation of the step name or a datatable row.
         """
         clean_line = line.strip()
-        if (clean_line.startswith("|") and clean_line.endswith("|")):
+        if clean_line.startswith("|") and clean_line.endswith("|"):
             # datatable line
             clean_line = clean_line[1:-1]
             self.datatable.append(clean_line.split("|"))
@@ -298,8 +294,7 @@ class Step:
 
     @property
     def name(self) -> str:
-        multilines_content = textwrap.dedent(
-            "\n".join(self.lines)) if self.lines else ""
+        multilines_content = textwrap.dedent("\n".join(self.lines)) if self.lines else ""
 
         # Remove the multiline quotes, if present.
         multilines_content = re.sub(
@@ -395,8 +390,7 @@ def get_tags(all_lines: list[str] | str | None, line_number: int = 0) -> set[str
         return set()
     else:
         while (line_number - 1) > 0 and all_lines[line_number - line_offset].strip().startswith("@"):
-            line_tags = {tag.lstrip(
-                "@") for tag in all_lines[line_number - 2].strip().split(" @") if len(tag) > 1}
+            line_tags = {tag.lstrip("@") for tag in all_lines[line_number - 2].strip().split(" @") if len(tag) > 1}
             total_tags = total_tags.union(line_tags)
             line_number -= 1
         return total_tags

--- a/src/pytest_bdd/scenario.py
+++ b/src/pytest_bdd/scenario.py
@@ -243,14 +243,17 @@ def _get_scenario_decorator(
 
 def collect_example_parametrizations(
     templated_scenario: ScenarioTemplate,
-) -> list[ParameterSet] | None:
+) -> tuple[list[ParameterSet], set[str]] | None:
     # We need to evaluate these iterators and store them as lists, otherwise
     # we won't be able to do the cartesian product later (the second iterator will be consumed)
     contexts = list(templated_scenario.examples.as_contexts())
     if not contexts:
         return None
+    return [pytest.param(context[0], id="-".join(context[0].values()), marks=_register_tags_as_marks(context[1])) for context in contexts]
 
-    return [pytest.param(context, id="-".join(context.values())) for context in contexts]
+
+def _register_tags_as_marks(tags) -> list[pytest.mark]:
+    return [getattr(pytest.mark, marks) for marks in tags]
 
 
 def scenario(


### PR DESCRIPTION
- updated pydocs description for Step and Step.add_line
- added `datatable` property
- init'ed `datatable` property
- modified `add_line` to check the line, if it starts and ends with a pipe `|` then we split the internals on the `|` and append that to the `datatable` property

Needs to be tested and confirmed to work.