### PR TITLE
fix step arguments with default value

### DIFF
--- a/src/pytest_bdd/scenario.py
+++ b/src/pytest_bdd/scenario.py
@@ -25,7 +25,7 @@ from _pytest.nodes import iterparentnodeids
 from . import exceptions
 from .feature import get_feature, get_features
 from .steps import StepFunctionContext, get_step_fixture_name, inject_fixture
-from .utils import CONFIG_STACK, get_args, get_caller_module_locals, get_caller_module_path
+from .utils import CONFIG_STACK, get_args, get_args_with_default_value, get_caller_module_locals, get_caller_module_path
 
 if TYPE_CHECKING:
     from typing import Any, Iterable
@@ -151,7 +151,12 @@ def _execute_step_function(
                 value = converters[arg](value)
             kwargs[arg] = value
 
-        kwargs = {arg: kwargs[arg] if arg in kwargs else request.getfixturevalue(arg) for arg in args}
+        for arg in args:
+            if not arg in kwargs:
+                if not arg in args_with_default:
+                    kwargs[arg] = request.getfixturevalue()
+                else:
+                    kwargs[arg] = args_with_default[arg]
         kw["step_func_args"] = kwargs
 
         request.config.hook.pytest_bdd_before_step_call(**kw)

--- a/src/pytest_bdd/utils.py
+++ b/src/pytest_bdd/utils.py
@@ -32,6 +32,17 @@ def get_args(func: Callable) -> list[str]:
         param.name for param in params if param.kind == param.POSITIONAL_OR_KEYWORD and param.default is param.empty
     ]
 
+def get_args_with_default_value(func: Callable) -> dict:
+    """Get a dictionary of arguments with default value
+    
+    :param func: The function to inspect
+    :return: A dictionary of arguments with default value
+    :rtype: dict"""
+    params = signature(func).parameters.values()
+    return {
+        param.name: param.default for param in params if not param.default == param.empty
+    }
+
 
 def get_caller_module_locals(stacklevel: int = 1) -> dict[str, Any]:
     """Get the caller module locals dictionary.


### PR DESCRIPTION
The bug is mentioned in the issue #607.
This is a sample implementation trying minimal invasive by implementing a new function that retrieves all arguments with default values.

Another solution would be to let `get_args` retrieve a `dict` with the arguments as keys and its values as values. But this would add two or three more changes I think, therefore I didn't implement this solution. 

I'm really looking forward hearing from you. 

Best
Samuel