### PR TITLE
Support asterisks as continuation steps on par with And and But

### DIFF
--- a/src/pytest_bdd/parser.py
+++ b/src/pytest_bdd/parser.py
@@ -26,6 +26,7 @@ STEP_PREFIXES = [
     # Continuation of the previously mentioned step type
     ("And ", None),
     ("But ", None),
+    ("* ", None),
 ]
 
 TYPES_WITH_DESCRIPTIONS = [types.FEATURE, types.SCENARIO, types.SCENARIO_OUTLINE]

--- a/tests/feature/test_steps.py
+++ b/tests/feature/test_steps.py
@@ -18,6 +18,13 @@ def test_steps(pytester):
                     And I append 3 to the list
                     Then foo should have value "foo"
                     But the list should be [1, 2, 3]
+
+                    Given there is a list
+                    When values appended via asterisks:
+                    * I append 1 to the list
+                    * I append 2 to the list
+                    * I append 3 to the list
+                    Then the list should be [1, 2, 3]
             """
         ),
     )
@@ -65,6 +72,9 @@ def test_steps(pytester):
         def _(results):
             assert results == [1, 2, 3]
 
+        @when("values appended via asterisks:")
+        def _():
+            pass
         """
         )
     )


### PR DESCRIPTION
[Gherkin Documentation mentions](https://cucumber.io/docs/gherkin/reference/#Asterisk) you can uses `*` (asterisk) to describe lists of things, same way as with `And` steps:
```gherkin
Scenario: All done
  Given I am out shopping
  * I have eggs
  * I have milk
  * I have butter
  When I check my list
  Then I don't need anything
```
Dunno if anybody actually needs such feature - since search for `asterisk` did not yield anything neither in PRs nor Issues. But since the change is literally 1 line of code, I thought I might propose it just as well and see what happens :smile: 

Not sure if the place for testing it is right (`tests/feature/test_steps.py`) or if it should be done someplace else tho.