### PR TITLE
fix(typing): improve decorator type hinting

### DIFF
--- a/src/pytest_bdd/reporting.py
+++ b/src/pytest_bdd/reporting.py
@@ -155,7 +155,7 @@ def step_error(
     feature: Feature,
     scenario: Scenario,
     step: Step,
-    step_func: Callable,
+    step_func: Callable[..., Any],
     step_func_args: dict,
     exception: Exception,
 ) -> None:
@@ -163,7 +163,13 @@ def step_error(
     request.node.__scenario_report__.fail()
 
 
-def before_step(request: FixtureRequest, feature: Feature, scenario: Scenario, step: Step, step_func: Callable) -> None:
+def before_step(
+    request: FixtureRequest,
+    feature: Feature,
+    scenario: Scenario,
+    step: Step,
+    step_func: Callable[..., Any],
+) -> None:
     """Store step start time."""
     request.node.__scenario_report__.add_step_report(StepReport(step=step))
 

--- a/src/pytest_bdd/steps.py
+++ b/src/pytest_bdd/steps.py
@@ -43,13 +43,15 @@ from typing import Any, Callable, Iterable, Literal, TypeVar
 
 import pytest
 from _pytest.fixtures import FixtureDef, FixtureRequest
+from typing_extensions import ParamSpec
 
 from .parser import Step
 from .parsers import StepParser, get_parser
 from .types import GIVEN, THEN, WHEN
 from .utils import get_caller_module_locals
 
-TCallable = TypeVar("TCallable", bound=Callable[..., Any])
+P = ParamSpec("P")
+T = TypeVar("T")
 
 
 @enum.unique
@@ -74,10 +76,10 @@ def get_step_fixture_name(step: Step) -> str:
 
 def given(
     name: str | StepParser,
-    converters: dict[str, Callable] | None = None,
+    converters: dict[str, Callable[[Any], Any]] | None = None,
     target_fixture: str | None = None,
     stacklevel: int = 1,
-) -> Callable:
+) -> Callable[[Callable[P, T]], Callable[P, T]]:
     """Given step decorator.
 
     :param name: Step name or a parser object.
@@ -93,10 +95,10 @@ def given(
 
 def when(
     name: str | StepParser,
-    converters: dict[str, Callable] | None = None,
+    converters: dict[str, Callable[[Any], Any]] | None = None,
     target_fixture: str | None = None,
     stacklevel: int = 1,
-) -> Callable:
+) -> Callable[[Callable[P, T]], Callable[P, T]]:
     """When step decorator.
 
     :param name: Step name or a parser object.
@@ -112,10 +114,10 @@ def when(
 
 def then(
     name: str | StepParser,
-    converters: dict[str, Callable] | None = None,
+    converters: dict[str, Callable[[Any], Any]] | None = None,
     target_fixture: str | None = None,
     stacklevel: int = 1,
-) -> Callable:
+) -> Callable[[Callable[P, T]], Callable[P, T]]:
     """Then step decorator.
 
     :param name: Step name or a parser object.
@@ -132,10 +134,10 @@ def then(
 def step(
     name: str | StepParser,
     type_: Literal["given", "when", "then"] | None = None,
-    converters: dict[str, Callable] | None = None,
+    converters: dict[str, Callable[[Any], Any]] | None = None,
     target_fixture: str | None = None,
     stacklevel: int = 1,
-) -> Callable[[TCallable], TCallable]:
+) -> Callable[[Callable[P, T]], Callable[P, T]]:
     """Generic step decorator.
 
     :param name: Step name as in the feature file.
@@ -155,7 +157,7 @@ def step(
     if converters is None:
         converters = {}
 
-    def decorator(func: TCallable) -> TCallable:
+    def decorator(func: Callable[P, T]) -> Callable[P, T]:
         parser = get_parser(name)
 
         context = StepFunctionContext(

--- a/src/pytest_bdd/steps.py
+++ b/src/pytest_bdd/steps.py
@@ -65,7 +65,7 @@ class StepFunctionContext:
     type: Literal["given", "when", "then"] | None
     step_func: Callable[..., Any]
     parser: StepParser
-    converters: dict[str, Callable[..., Any]] = field(default_factory=dict)
+    converters: dict[str, Callable[[str], Any]] = field(default_factory=dict)
     target_fixture: str | None = None
 
 
@@ -76,7 +76,7 @@ def get_step_fixture_name(step: Step) -> str:
 
 def given(
     name: str | StepParser,
-    converters: dict[str, Callable[[Any], Any]] | None = None,
+    converters: dict[str, Callable[[str], Any]] | None = None,
     target_fixture: str | None = None,
     stacklevel: int = 1,
 ) -> Callable[[Callable[P, T]], Callable[P, T]]:
@@ -95,7 +95,7 @@ def given(
 
 def when(
     name: str | StepParser,
-    converters: dict[str, Callable[[Any], Any]] | None = None,
+    converters: dict[str, Callable[[str], Any]] | None = None,
     target_fixture: str | None = None,
     stacklevel: int = 1,
 ) -> Callable[[Callable[P, T]], Callable[P, T]]:
@@ -114,7 +114,7 @@ def when(
 
 def then(
     name: str | StepParser,
-    converters: dict[str, Callable[[Any], Any]] | None = None,
+    converters: dict[str, Callable[[str], Any]] | None = None,
     target_fixture: str | None = None,
     stacklevel: int = 1,
 ) -> Callable[[Callable[P, T]], Callable[P, T]]:
@@ -134,7 +134,7 @@ def then(
 def step(
     name: str | StepParser,
     type_: Literal["given", "when", "then"] | None = None,
-    converters: dict[str, Callable[[Any], Any]] | None = None,
+    converters: dict[str, Callable[[str], Any]] | None = None,
     target_fixture: str | None = None,
     stacklevel: int = 1,
 ) -> Callable[[Callable[P, T]], Callable[P, T]]:

--- a/src/pytest_bdd/utils.py
+++ b/src/pytest_bdd/utils.py
@@ -19,7 +19,7 @@ T = TypeVar("T")
 CONFIG_STACK: list[Config] = []
 
 
-def get_args(func: Callable) -> list[str]:
+def get_args(func: Callable[..., Any]) -> list[str]:
     """Get a list of argument names for a function.
 
     :param func: The function to inspect.


### PR DESCRIPTION
The type hinting for the most commonly used decorators were incomplete, resulting in decorated functions being obscured.

This makes use of a `TypeVar` which allows the return type of the decorator to be the same as its input.

I have also taken the opportunity to fix other instances of `Callable` type hints missing their arguments.

---

PS:

The benefit of moving `import` statement behind the `if TYPE_CHECKING` block is to avoid unnecessary parsing of libraries at runtime (when no type checking takes place). There were a few cases of:

```python
from typing import TYPE_CHECKING

if TYPE_CHECKING:
    from typing import Callable
```

which provides no benefit as the `typing` library has to be parsed in the first place anyway.

I hope it's alright that I fixed a couple of these :)