### PR TITLE
Adapt to `getfixturedefs` change in pytest 8.1

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,7 @@ Changelog
 
 Unreleased
 ----------
+- Address compatibility issue with pytest 8.1. `#666 <https://github.com/pytest-dev/pytest-bdd/pull/666>`_
 
 7.0.1
 -----

--- a/poetry.lock
+++ b/poetry.lock
@@ -552,4 +552,4 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8"
-content-hash = "5b7935aa2b2d579d4fdb8361b414d37fff142a359332d859ed1513209ca3b1a6"
+content-hash = "b40d47067f444deec4964404014795593f1b602f8a2f6376279bb5a27d5e18be"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ parse = "*"
 parse-type = "*"
 pytest = ">=6.2.0"
 typing-extensions = "*"
+packaging = "*"
 
 [tool.poetry.group.dev.dependencies]
 tox = ">=4.11.3"

--- a/src/pytest_bdd/compat.py
+++ b/src/pytest_bdd/compat.py
@@ -1,0 +1,21 @@
+from collections.abc import Sequence
+from importlib.metadata import version
+from typing import Optional
+
+from _pytest.fixtures import FixtureDef, FixtureManager
+from _pytest.nodes import Node
+from packaging.version import Version
+from packaging.version import parse as parse_version
+
+pytest_version = parse_version(version("pytest"))
+
+
+if pytest_version >= Version("8.1"):
+
+    def getfixturedefs(fixturemanager: FixtureManager, fixturename: str, node: Node) -> Optional[Sequence[FixtureDef]]:
+        return fixturemanager.getfixturedefs(fixturename, node)
+
+else:
+
+    def getfixturedefs(fixturemanager: FixtureManager, fixturename: str, node: Node) -> Optional[Sequence[FixtureDef]]:
+        return fixturemanager.getfixturedefs(fixturename, node.nodeid)

--- a/src/pytest_bdd/compat.py
+++ b/src/pytest_bdd/compat.py
@@ -1,6 +1,7 @@
+from __future__ import annotations
+
 from collections.abc import Sequence
 from importlib.metadata import version
-from typing import Optional
 
 from _pytest.fixtures import FixtureDef, FixtureManager
 from _pytest.nodes import Node
@@ -12,10 +13,10 @@ pytest_version = parse_version(version("pytest"))
 
 if pytest_version >= Version("8.1"):
 
-    def getfixturedefs(fixturemanager: FixtureManager, fixturename: str, node: Node) -> Optional[Sequence[FixtureDef]]:
+    def getfixturedefs(fixturemanager: FixtureManager, fixturename: str, node: Node) -> Sequence[FixtureDef] | None:
         return fixturemanager.getfixturedefs(fixturename, node)
 
 else:
 
-    def getfixturedefs(fixturemanager: FixtureManager, fixturename: str, node: Node) -> Optional[Sequence[FixtureDef]]:
+    def getfixturedefs(fixturemanager: FixtureManager, fixturename: str, node: Node) -> Sequence[FixtureDef] | None:
         return fixturemanager.getfixturedefs(fixturename, node.nodeid)

--- a/src/pytest_bdd/generation.py
+++ b/src/pytest_bdd/generation.py
@@ -5,10 +5,10 @@ import itertools
 import os.path
 from typing import TYPE_CHECKING, cast
 
-import pytest
 from _pytest._io import TerminalWriter
 from mako.lookup import TemplateLookup
 
+from .compat import getfixturedefs
 from .feature import get_features
 from .scenario import inject_fixturedefs_for_step, make_python_docstring, make_python_name, make_string_literal
 from .steps import get_step_fixture_name
@@ -130,10 +130,7 @@ def _find_step_fixturedef(
     """Find step fixturedef."""
     with inject_fixturedefs_for_step(step=step, fixturemanager=fixturemanager, node=item):
         bdd_name = get_step_fixture_name(step=step)
-        if hasattr(pytest, "version_tuple") and pytest.version_tuple >= (8, 1):
-            return fixturemanager.getfixturedefs(bdd_name, item)
-        else:
-            return fixturemanager.getfixturedefs(bdd_name, item.nodeid)
+        return getfixturedefs(fixturemanager, bdd_name, item)
 
 
 def parse_feature_files(paths: list[str], **kwargs: Any) -> tuple[list[Feature], list[ScenarioTemplate], list[Step]]:

--- a/src/pytest_bdd/generation.py
+++ b/src/pytest_bdd/generation.py
@@ -5,6 +5,7 @@ import itertools
 import os.path
 from typing import TYPE_CHECKING, cast
 
+import pytest
 from _pytest._io import TerminalWriter
 from mako.lookup import TemplateLookup
 
@@ -127,9 +128,12 @@ def _find_step_fixturedef(
     fixturemanager: FixtureManager, item: Function, step: Step
 ) -> Sequence[FixtureDef[Any]] | None:
     """Find step fixturedef."""
-    with inject_fixturedefs_for_step(step=step, fixturemanager=fixturemanager, nodeid=item.nodeid):
+    with inject_fixturedefs_for_step(step=step, fixturemanager=fixturemanager, node=item):
         bdd_name = get_step_fixture_name(step=step)
-        return fixturemanager.getfixturedefs(bdd_name, item.nodeid)
+        if hasattr(pytest, "version_tuple") and pytest.version_tuple >= (8, 1):
+            return fixturemanager.getfixturedefs(bdd_name, item)
+        else:
+            return fixturemanager.getfixturedefs(bdd_name, item.nodeid)
 
 
 def parse_feature_files(paths: list[str], **kwargs: Any) -> tuple[list[Feature], list[ScenarioTemplate], list[Step]]:


### PR DESCRIPTION
The signature of this (private) function will change in the upcoming pytest 8.1 release:
https://github.com/pytest-dev/pytest/pull/11785

Additionally, the `iterparentnodeids` function is removed, so copy/pasting it for now.

I verified that all tests pass when run against pytest main.