### PR TITLE
Test parser rejects steps not using title-cased step keywords

### DIFF
--- a/tests/feature/test_steps.py
+++ b/tests/feature/test_steps.py
@@ -1,5 +1,4 @@
 import textwrap
-from idlelib.iomenu import errors
 
 
 def test_steps(pytester):


### PR DESCRIPTION
Resolves #230 