### PR TITLE
Don't hardcode keywords

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Unreleased
 ----------
 - Dropped support for python 3.8. Supported python versions: 3.9, 3.10, 3.11, 3.12, 3.13.
 - Text after the `#` character is no longer stripped from the Scenario and Feature name.
+- All gherkin-compliant keywords permitted in feature-files and correctly reported in json and terminal output.
 
 8.0.0b2
 ----------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Unreleased
 ----------
 - Dropped support for python 3.8. Supported python versions: 3.9, 3.10, 3.11, 3.12, 3.13.
 - Text after the `#` character is no longer stripped from the Scenario and Feature name.
-- All gherkin-compliant keywords permitted in feature-files and correctly reported in json and terminal output.
+- Gherkin keyword aliases can now be used and correctly reported in json and terminal output (see `Keywords <https://cucumber.io/docs/gherkin/reference/#keywords>` for permitted list.
 
 8.0.0b2
 ----------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Unreleased
 ----------
 - Dropped support for python 3.8. Supported python versions: 3.9, 3.10, 3.11, 3.12, 3.13.
 - Text after the `#` character is no longer stripped from the Scenario and Feature name.
-- Gherkin keyword aliases can now be used and correctly reported in json and terminal output (see `Keywords <https://cucumber.io/docs/gherkin/reference/#keywords>` for permitted list.
+- Gherkin keyword aliases can now be used and correctly reported in json and terminal output (see `Keywords <https://cucumber.io/docs/gherkin/reference/#keywords>` for permitted list).
 
 8.0.0b2
 ----------

--- a/src/pytest_bdd/cucumber_json.py
+++ b/src/pytest_bdd/cucumber_json.py
@@ -114,7 +114,7 @@ class LogBDDCucumberJSON:
 
         if scenario["feature"]["filename"] not in self.features:
             self.features[scenario["feature"]["filename"]] = {
-                "keyword": "Feature",
+                "keyword": scenario["feature"]["keyword"],
                 "uri": scenario["feature"]["rel_filename"],
                 "name": scenario["feature"]["name"] or scenario["feature"]["rel_filename"],
                 "id": scenario["feature"]["rel_filename"].lower().replace(" ", "-"),
@@ -126,7 +126,7 @@ class LogBDDCucumberJSON:
 
         self.features[scenario["feature"]["filename"]]["elements"].append(
             {
-                "keyword": "Scenario",
+                "keyword": scenario["keyword"],
                 "id": report.item["name"],
                 "name": scenario["name"],
                 "line": scenario["line_number"],

--- a/src/pytest_bdd/gherkin_terminal_reporter.py
+++ b/src/pytest_bdd/gherkin_terminal_reporter.py
@@ -72,20 +72,20 @@ class GherkinTerminalReporter(TerminalReporter):  # type: ignore
 
         if self.verbosity == 1:
             self.ensure_newline()
-            self._tw.write("Feature: ", **feature_markup)
+            self._tw.write(f"{report.scenario['feature']['keyword']}: ", **feature_markup)
             self._tw.write(report.scenario["feature"]["name"], **feature_markup)
             self._tw.write("\n")
-            self._tw.write("    Scenario: ", **scenario_markup)
+            self._tw.write(f"    {report.scenario['keyword']}: ", **scenario_markup)
             self._tw.write(report.scenario["name"], **scenario_markup)
             self._tw.write(" ")
             self._tw.write(word, **word_markup)
             self._tw.write("\n")
         elif self.verbosity > 1:
             self.ensure_newline()
-            self._tw.write("Feature: ", **feature_markup)
+            self._tw.write(f"{report.scenario['feature']['keyword']}: ", **feature_markup)
             self._tw.write(report.scenario["feature"]["name"], **feature_markup)
             self._tw.write("\n")
-            self._tw.write("    Scenario: ", **scenario_markup)
+            self._tw.write(f"    {report.scenario['keyword']}: ", **scenario_markup)
             self._tw.write(report.scenario["name"], **scenario_markup)
             self._tw.write("\n")
             for step in report.scenario["steps"]:

--- a/src/pytest_bdd/parser.py
+++ b/src/pytest_bdd/parser.py
@@ -40,6 +40,7 @@ class Feature:
     scenarios: OrderedDict[str, ScenarioTemplate]
     filename: str
     rel_filename: str
+    keyword: str
     name: str | None
     tags: set[str]
     background: Background | None
@@ -104,6 +105,7 @@ class ScenarioTemplate:
 
     Attributes:
         feature (Feature): The feature to which this scenario belongs.
+        keyword (str): The keyword used to define the scenario.
         name (str): The name of the scenario.
         line_number (int): The line number where the scenario starts in the file.
         templated (bool): Whether the scenario is templated.
@@ -114,6 +116,7 @@ class ScenarioTemplate:
     """
 
     feature: Feature
+    keyword: str
     name: str
     line_number: int
     templated: bool
@@ -165,6 +168,7 @@ class ScenarioTemplate:
         steps = background_steps + scenario_steps
         return Scenario(
             feature=self.feature,
+            keyword=self.keyword,
             name=self.name,
             line_number=self.line_number,
             steps=steps,
@@ -179,6 +183,7 @@ class Scenario:
 
     Attributes:
         feature (Feature): The feature to which this scenario belongs.
+        keyword (str): The keyword used to define the scenario.
         name (str): The name of the scenario.
         line_number (int): The line number where the scenario starts in the file.
         steps (List[Step]): The list of steps in the scenario.
@@ -187,6 +192,7 @@ class Scenario:
     """
 
     feature: Feature
+    keyword: str
     name: str
     line_number: int
     steps: list[Step]
@@ -386,6 +392,7 @@ class FeatureParser:
         templated = bool(scenario_data.examples)
         scenario = ScenarioTemplate(
             feature=feature,
+            keyword=scenario_data.keyword,
             name=scenario_data.name,
             line_number=scenario_data.location.line,
             templated=templated,
@@ -434,6 +441,7 @@ class FeatureParser:
         feature_data: GherkinFeature = gherkin_doc.feature
         feature = Feature(
             scenarios=OrderedDict(),
+            keyword=feature_data.keyword,
             filename=self.abs_filename,
             rel_filename=self.rel_filename,
             name=feature_data.name,

--- a/src/pytest_bdd/reporting.py
+++ b/src/pytest_bdd/reporting.py
@@ -110,10 +110,12 @@ class ScenarioReport:
 
         return {
             "steps": [step_report.serialize() for step_report in self.step_reports],
+            "keyword": scenario.keyword,
             "name": scenario.name,
             "line_number": scenario.line_number,
             "tags": sorted(scenario.tags),
             "feature": {
+                "keyword": feature.keyword,
                 "name": feature.name,
                 "filename": feature.filename,
                 "rel_filename": feature.rel_filename,

--- a/tests/feature/test_cucumber_json.py
+++ b/tests/feature/test_cucumber_json.py
@@ -170,7 +170,7 @@ def test_step_trace(pytester):
                 },
                 {
                     "description": "",
-                    "keyword": "Scenario",
+                    "keyword": "Scenario Outline",
                     "tags": [{"line": 14, "name": "scenario-outline-passing-tag"}],
                     "steps": [
                         {
@@ -188,7 +188,7 @@ def test_step_trace(pytester):
                 },
                 {
                     "description": "",
-                    "keyword": "Scenario",
+                    "keyword": "Scenario Outline",
                     "tags": [{"line": 14, "name": "scenario-outline-passing-tag"}],
                     "steps": [
                         {
@@ -206,7 +206,7 @@ def test_step_trace(pytester):
                 },
                 {
                     "description": "",
-                    "keyword": "Scenario",
+                    "keyword": "Scenario Outline",
                     "tags": [{"line": 14, "name": "scenario-outline-passing-tag"}],
                     "steps": [
                         {

--- a/tests/feature/test_gherkin_terminal_reporter.py
+++ b/tests/feature/test_gherkin_terminal_reporter.py
@@ -231,7 +231,7 @@ def test_step_parameters_should_be_replaced_by_their_values(pytester):
 
     result = pytester.runpytest("--gherkin-terminal-reporter", "-vv")
     result.assert_outcomes(passed=1, failed=0)
-    result.stdout.fnmatch_lines("*Scenario: Scenario example 2")
+    result.stdout.fnmatch_lines("*Scenario Outline: Scenario example 2")
     result.stdout.fnmatch_lines("*Given there are {start} cucumbers".format(**example))
     result.stdout.fnmatch_lines("*When I eat {eat} cucumbers".format(**example))
     result.stdout.fnmatch_lines("*Then I should have {left} cucumbers".format(**example))

--- a/tests/feature/test_report.py
+++ b/tests/feature/test_report.py
@@ -106,12 +106,14 @@ def test_step_trace(pytester):
     expected = {
         "feature": {
             "description": "",
+            "keyword": "Feature",
             "filename": str(feature),
             "line_number": 2,
             "name": "One passing scenario, one failing scenario",
             "rel_filename": str(relpath),
             "tags": ["feature-tag"],
         },
+        "keyword": "Scenario",
         "line_number": 5,
         "name": "Passing",
         "steps": [
@@ -141,12 +143,14 @@ def test_step_trace(pytester):
     expected = {
         "feature": {
             "description": "",
+            "keyword": "Feature",
             "filename": str(feature),
             "line_number": 2,
             "name": "One passing scenario, one failing scenario",
             "rel_filename": str(relpath),
             "tags": ["feature-tag"],
         },
+        "keyword": "Scenario",
         "line_number": 10,
         "name": "Failing",
         "steps": [
@@ -175,12 +179,14 @@ def test_step_trace(pytester):
     expected = {
         "feature": {
             "description": "",
+            "keyword": "Feature",
             "filename": str(feature),
             "line_number": 2,
             "name": "One passing scenario, one failing scenario",
             "rel_filename": str(relpath),
             "tags": ["feature-tag"],
         },
+        "keyword": "Scenario Outline",
         "line_number": 14,
         "name": "Outlined",
         "steps": [
@@ -217,12 +223,14 @@ def test_step_trace(pytester):
     expected = {
         "feature": {
             "description": "",
+            "keyword": "Feature",
             "filename": str(feature),
             "line_number": 2,
             "name": "One passing scenario, one failing scenario",
             "rel_filename": str(relpath),
             "tags": ["feature-tag"],
         },
+        "keyword": "Scenario Outline",
         "line_number": 14,
         "name": "Outlined",
         "steps": [


### PR DESCRIPTION
Propogate keywords from gherkin parser to allow for internationalisation and using valid aliases for keywords