### PR TITLE
fix: default value not covered by parameters passed through feature file

### DIFF
--- a/src/pytest_bdd/scenario.py
+++ b/src/pytest_bdd/scenario.py
@@ -235,6 +235,8 @@ def _execute_step_function(
 
         request.config.hook.pytest_bdd_before_step_call(**kw)
 
+        # Execute the step as if it was a pytest fixture using `call_fixture_func`,
+        # so that we can allow "yield" statements in it
         return_value = call_fixture_func(fixturefunc=context.step_func, request=request, kwargs=kwargs)
 
     except Exception as exception:

--- a/src/pytest_bdd/scenario.py
+++ b/src/pytest_bdd/scenario.py
@@ -182,7 +182,7 @@ def _execute_step_function(
     func_sig = signature(context.step_func)
     converters = context.converters
 
-    def _get_parsed_arguments():
+    def _get_parsed_arguments() -> dict:
         """Parse and convert step arguments."""
         parsed_args = context.parser.parse_arguments(step.name)
         if parsed_args is None:
@@ -196,7 +196,7 @@ def _execute_step_function(
                 kwargs[arg] = value
         return kwargs
 
-    def _get_argument_values(kwargs):
+    def _get_argument_values(kwargs: dict) -> dict:
         """Get default values or request fixture values for missing arguments."""
         for arg in get_args(context.step_func):
             if arg not in kwargs:

--- a/src/pytest_bdd/scenario.py
+++ b/src/pytest_bdd/scenario.py
@@ -205,12 +205,6 @@ def _execute_step_function(
 
     func_sig = signature(context.step_func)
 
-    def _get_parsed_arguments() -> dict:
-        """Parse and convert step arguments."""
-        parsed_args = parse_step_arguments(step=step, context=context)
-
-        return {k: v for k, v in parsed_args.items() if k in func_sig.parameters}
-
     def _get_argument_values(kwargs: dict) -> dict:
         """Get default values or request fixture values for missing arguments."""
         for arg in get_args(context.step_func):
@@ -235,7 +229,8 @@ def _execute_step_function(
 
     try:
         # Use internal methods without passing redundant arguments
-        kwargs = _get_parsed_arguments()
+        parsed_args = parse_step_arguments(step=step, context=context)
+        kwargs = {k: v for k, v in parsed_args.items() if k in func_sig.parameters}
 
         if STEP_ARGUMENT_DATATABLE in func_sig.parameters and step.datatable is not None:
             kwargs[STEP_ARGUMENT_DATATABLE] = step.datatable.raw()

--- a/src/pytest_bdd/scenario.py
+++ b/src/pytest_bdd/scenario.py
@@ -186,9 +186,7 @@ def _execute_step_function(
         """Parse and convert step arguments."""
         parsed_args = context.parser.parse_arguments(step.name)
         if parsed_args is None:
-            raise ValueError(
-                f"Unexpected `NoneType` returned from parse_arguments(...) in parser: {context.parser!r}"
-            )
+            raise ValueError(f"Unexpected `NoneType` returned from parse_arguments(...) in parser: {context.parser!r}")
         kwargs = {}
         for arg, value in parsed_args.items():
             param = func_sig.parameters.get(arg)

--- a/src/pytest_bdd/scenario.py
+++ b/src/pytest_bdd/scenario.py
@@ -218,6 +218,8 @@ def _execute_step_function(
     try:
         # Use internal methods without passing redundant arguments
         parsed_args = parse_step_arguments(step=step, context=context)
+
+        # Filter out the arguments that are not in the function signature
         kwargs = {k: v for k, v in parsed_args.items() if k in func_sig.parameters}
 
         if STEP_ARGUMENT_DATATABLE in func_sig.parameters and step.datatable is not None:

--- a/src/pytest_bdd/scenario.py
+++ b/src/pytest_bdd/scenario.py
@@ -205,18 +205,6 @@ def _execute_step_function(
 
     func_sig = signature(context.step_func)
 
-    def _get_argument_values(kwargs: dict) -> dict:
-        """Get default values or request fixture values for missing arguments."""
-        for arg in get_args(context.step_func):
-            if arg not in kwargs:
-                param = func_sig.parameters.get(arg)
-                if param:
-                    if param.default != param.empty:
-                        kwargs[arg] = param.default
-                    else:
-                        kwargs[arg] = request.getfixturevalue(arg)
-        return kwargs
-
     kw = {
         "request": request,
         "feature": scenario.feature,
@@ -237,7 +225,8 @@ def _execute_step_function(
         if STEP_ARGUMENT_DOCSTRING in func_sig.parameters and step.docstring is not None:
             kwargs[STEP_ARGUMENT_DOCSTRING] = step.docstring
 
-        kwargs = _get_argument_values(kwargs)
+        # Fill the missing arguments requesting the fixture values
+        kwargs |= {arg: request.getfixturevalue(arg) for arg in get_args(context.step_func) if arg not in kwargs}
 
         kw["step_func_args"] = kwargs
 

--- a/src/pytest_bdd/scenario.py
+++ b/src/pytest_bdd/scenario.py
@@ -216,7 +216,6 @@ def _execute_step_function(
     request.config.hook.pytest_bdd_before_step(**kw)
 
     try:
-        # Use internal methods without passing redundant arguments
         parsed_args = parse_step_arguments(step=step, context=context)
 
         # Filter out the arguments that are not in the function signature

--- a/src/pytest_bdd/scenario.py
+++ b/src/pytest_bdd/scenario.py
@@ -29,7 +29,7 @@ from . import exceptions
 from .compat import getfixturedefs, inject_fixture
 from .feature import get_feature, get_features
 from .steps import StepFunctionContext, get_step_fixture_name
-from .utils import CONFIG_STACK, get_args, get_caller_module_locals, get_caller_module_path, identity
+from .utils import CONFIG_STACK, get_caller_module_locals, get_caller_module_path, get_required_args, identity
 
 if TYPE_CHECKING:
     from _pytest.mark.structures import ParameterSet
@@ -227,7 +227,9 @@ def _execute_step_function(
             kwargs[STEP_ARGUMENT_DOCSTRING] = step.docstring
 
         # Fill the missing arguments requesting the fixture values
-        kwargs |= {arg: request.getfixturevalue(arg) for arg in get_args(context.step_func) if arg not in kwargs}
+        kwargs |= {
+            arg: request.getfixturevalue(arg) for arg in get_required_args(context.step_func) if arg not in kwargs
+        }
 
         kw["step_func_args"] = kwargs
 
@@ -287,7 +289,7 @@ def _get_scenario_decorator(
                 "scenario function can only be used as a decorator. Refer to the documentation."
             )
         [fn] = args
-        func_args = get_args(fn)
+        func_args = get_required_args(fn)
 
         def scenario_wrapper(request: FixtureRequest, _pytest_bdd_example: dict[str, str]) -> Any:
             __tracebackhide__ = True

--- a/src/pytest_bdd/scenario.py
+++ b/src/pytest_bdd/scenario.py
@@ -210,7 +210,9 @@ def _execute_step_function(
         if step.docstring is not None:
             kwargs["docstring"] = step.docstring
 
-        kwargs = {arg: kwargs[arg] if arg in kwargs else request.getfixturevalue(arg) for arg in args}
+        for arg in args:
+            if arg not in kwargs:
+                kwargs[arg] = request.getfixturevalue(arg)
 
         kw["step_func_args"] = kwargs
 

--- a/src/pytest_bdd/utils.py
+++ b/src/pytest_bdd/utils.py
@@ -20,13 +20,12 @@ T = TypeVar("T")
 CONFIG_STACK: list[Config] = []
 
 
-def get_args(func: Callable[..., Any]) -> list[str]:
-    """Get a list of argument names for a function.
+def get_required_args(func: Callable[..., Any]) -> list[str]:
+    """Get a list of argument that are required for a function.
 
     :param func: The function to inspect.
 
     :return: A list of argument names.
-    :rtype: list
     """
     params = signature(func).parameters.values()
     return [


### PR DESCRIPTION
**Describe the bug**
when given multi description for step as below code

```
@given('a user with username')
@given(parsers.parse('a user with username {username}'))
@given(parsers.parse('a user with username {username} and password {password}'))
def create_user(user, username="defaultuser", password='defaultpassword'):
    user['username'] = username
    user['password'] = password
```
and pass parameters from feature file in Scenario Outline
```  
Scenario Outline: User login
    Given a user with username <username> and password <password>
    When the user logs in with username <username> and password <password>
    Then the login should be <result>

    Examples:
      | username | password    | result  |
      | testuser | password123 | success |
```
Parameters username, password parameters passed through feature file cannot take effect.
The default values in def are always used。
in above case, the result is
```
user = {
    'username': 'defaultuser',
    'password': 'defaultpassword'
}
```

see also:
https://github.com/pytest-dev/pytest-bdd/pull/610 pr fix this problems

Supersedes #610 
Resolves #512 
Resolves #198 