### PR TITLE
Render docstrings and datatable cells with example table entries

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,6 +24,7 @@ Removed
 Fixed
 +++++
 * Fixed an issue with the upcoming pytest release related to the use of ``@pytest.mark.usefixtures`` with an empty list.
+* Render template variables in docstrings and datatable cells with example table entries, as we already do for steps definitions.
 
 Security
 ++++++++

--- a/README.rst
+++ b/README.rst
@@ -514,8 +514,7 @@ Example:
         assert cucumbers["start"] - cucumbers["eat"] == left
 
 
-Example parameters from example tables can not only be used in step names with angular brackets (e.g., <start>),
-but also embedded directly within docstrings and datatables, allowing for dynamic substitution.
+Example parameters from example tables can not only be used in steps, but also embedded directly within docstrings and datatables, allowing for dynamic substitution.
 This provides added flexibility for scenarios that require complex setups or validations.
 
 Example:

--- a/README.rst
+++ b/README.rst
@@ -513,6 +513,59 @@ Example:
     def should_have_left_cucumbers(cucumbers, left):
         assert cucumbers["start"] - cucumbers["eat"] == left
 
+
+Example parameters from example tables can not only be used in step names with angular brackets (e.g., <start>),
+but also embedded directly within docstrings and datatables, allowing for dynamic substitution.
+This provides added flexibility for scenarios that require complex setups or validations.
+
+Example:
+
+.. code-block:: gherkin
+
+    # content of docstring_and_datatable_with_params.feature
+
+    Feature: Docstring and Datatable with example parameters
+        Scenario Outline: Using parameters in docstrings and datatables
+            Given the following configuration:
+                """
+                username: <username>
+                password: <password>
+                """
+            When the user logs in
+            Then the response should contain:
+                | field     | value       |
+                | username  | <username> |
+                | logged_in | true        |
+
+            Examples:
+            | username  | password  |
+            | user1     | pass123   |
+            | user2     | 123secure |
+
+.. code-block:: python
+
+    from pytest_bdd import scenarios, given, when, then
+    import json
+
+    # Load scenarios from the feature file
+    scenarios("docstring_and_datatable_with_params.feature")
+
+
+    @given("the following configuration:")
+    def given_user_config(docstring):
+        print(docstring)
+
+
+    @when("the user logs in")
+    def user_logs_in(logged_in):
+        logged_in = True
+
+
+    @then("the response should contain:")
+    def response_should_contain(datatable):
+        assert datatable[1][1] in ["user1", "user2"]
+
+
 Rules
 -----
 

--- a/README.rst
+++ b/README.rst
@@ -533,9 +533,9 @@ Example:
                 """
             When the user logs in
             Then the response should contain:
-                | field     | value       |
+                | field     | value      |
                 | username  | <username> |
-                | logged_in | true        |
+                | logged_in | true       |
 
             Examples:
             | username  | password  |

--- a/src/pytest_bdd/parser.py
+++ b/src/pytest_bdd/parser.py
@@ -21,7 +21,7 @@ from .gherkin_parser import Tag as GherkinTag
 from .gherkin_parser import get_gherkin_document
 from .types import STEP_TYPE_BY_PARSER_KEYWORD
 
-STEP_PARAM_RE = re.compile(r"<(.+?)>")
+PARAM_RE = re.compile(r"<(.+?)>")
 
 
 def render_string(input_string: str, render_context: Mapping[str, object]) -> str:
@@ -42,7 +42,7 @@ def render_string(input_string: str, render_context: Mapping[str, object]) -> st
         # If the context contains the variable, replace it. Otherwise, leave it unchanged.
         return str(render_context.get(varname, f"<{varname}>"))
 
-    return STEP_PARAM_RE.sub(replacer, input_string)
+    return PARAM_RE.sub(replacer, input_string)
 
 
 def get_tag_names(tag_data: list[GherkinTag]) -> set[str]:

--- a/src/pytest_bdd/parser.py
+++ b/src/pytest_bdd/parser.py
@@ -321,15 +321,6 @@ class Step:
         """
         return f'{self.type.capitalize()} "{self.name}"'
 
-    @property
-    def params(self) -> tuple[str, ...]:
-        """Get the parameters in the step name.
-
-        Returns:
-            Tuple[str, ...]: A tuple of parameter names found in the step name.
-        """
-        return tuple(frozenset(PARAM_RE.findall(self.name)))
-
     @staticmethod
     def render_datatable(datatable: DataTable, context: Mapping[str, object]) -> DataTable:
         """

--- a/src/pytest_bdd/parser.py
+++ b/src/pytest_bdd/parser.py
@@ -23,14 +23,14 @@ from .types import STEP_TYPE_BY_PARSER_KEYWORD
 STEP_PARAM_RE = re.compile(r"<(.+?)>")
 
 
-def render_string(input_string: str, render_context: Mapping[str, Any]) -> str:
+def render_string(input_string: str, render_context: Mapping[str, object]) -> str:
     """
     Render the string with the given context,
     but avoid replacing text inside angle brackets if context is missing.
 
     Args:
         input_string (str): The string for which to render/replace params.
-        render_context (Mapping[str, Any]): The context for rendering the string.
+        render_context (Mapping[str, object]): The context for rendering the string.
 
     Returns:
         str: The rendered string with parameters replaced only if they exist in the context.

--- a/src/pytest_bdd/parser.py
+++ b/src/pytest_bdd/parser.py
@@ -213,13 +213,13 @@ class ScenarioTemplate:
         base_steps = self.all_background_steps + self._steps
         scenario_steps = [
             Step(
-                name=step.render_step_name(context),
+                name=render_string(step.name, context),
                 type=step.type,
                 indent=step.indent,
                 line_number=step.line_number,
                 keyword=step.keyword,
                 datatable=step.render_datatable(context),
-                docstring=step.render_docstring(context),
+                docstring=render_string(step.docstring, context) if step.docstring else None,
             )
             for step in base_steps
         ]
@@ -329,19 +329,6 @@ class Step:
         """
         return tuple(frozenset(STEP_PARAM_RE.findall(self.name)))
 
-    def render_step_name(self, context: Mapping[str, Any]) -> str:
-        """
-        Render the step name with the given context,
-        but avoid replacing text inside angle brackets if context is missing.
-
-        Args:
-            context (Mapping[str, Any]): The context for rendering the step name.
-
-        Returns:
-            str: The rendered step name with parameters replaced only if they exist in the context.
-        """
-        return render_string(self.name, context)
-
     def render_datatable(self, context: Mapping[str, Any]) -> DataTable | None:
         """
         Render the datatable with the given context,
@@ -360,19 +347,6 @@ class Step:
                     cell.value = render_string(cell.value, context)
             return rendered_datatable
         return None
-
-    def render_docstring(self, context: Mapping[str, Any]) -> str | None:
-        """
-        Render the docstring with the given context,
-        but avoid replacing text inside angle brackets if context is missing.
-
-        Args:
-            context (Mapping[str, Any]): The context for rendering the docstring.
-
-        Returns:
-            str: The rendered docstring with parameters replaced only if they exist in the context.
-        """
-        return render_string(self.docstring, context) if self.docstring else None
 
 
 @dataclass(eq=False)

--- a/src/pytest_bdd/parser.py
+++ b/src/pytest_bdd/parser.py
@@ -328,7 +328,7 @@ class Step:
         Returns:
             Tuple[str, ...]: A tuple of parameter names found in the step name.
         """
-        return tuple(frozenset(STEP_PARAM_RE.findall(self.name)))
+        return tuple(frozenset(PARAM_RE.findall(self.name)))
 
     @staticmethod
     def render_datatable(datatable: DataTable, context: Mapping[str, object]) -> DataTable:

--- a/src/pytest_bdd/parser.py
+++ b/src/pytest_bdd/parser.py
@@ -210,6 +210,7 @@ class ScenarioTemplate:
         Returns:
             Scenario: A Scenario object with steps rendered based on the context.
         """
+        base_steps = self.all_background_steps + self._steps
         scenario_steps = [
             Step(
                 name=step.render_step_name(context),
@@ -220,15 +221,14 @@ class ScenarioTemplate:
                 datatable=step.render_datatable(context),
                 docstring=step.render_docstring(context),
             )
-            for step in self._steps
+            for step in base_steps
         ]
-        steps = self.all_background_steps + scenario_steps
         return Scenario(
             feature=self.feature,
             keyword=self.keyword,
-            name=self.name,
+            name=render_string(self.name, context),
             line_number=self.line_number,
-            steps=steps,
+            steps=scenario_steps,
             tags=self.tags,
             description=self.description,
             rule=self.rule,

--- a/src/pytest_bdd/parser.py
+++ b/src/pytest_bdd/parser.py
@@ -342,7 +342,7 @@ class Step:
         """
         return render_string(self.name, context)
 
-    def render_datatable(self, context: Mapping[str, Any]) -> datatable | None:
+    def render_datatable(self, context: Mapping[str, Any]) -> DataTable | None:
         """
         Render the datatable with the given context,
         but avoid replacing text inside angle brackets if context is missing.
@@ -351,7 +351,7 @@ class Step:
             context (Mapping[str, Any]): The context for rendering the datatable.
 
         Returns:
-            datatable: The rendered datatable with parameters replaced only if they exist in the context.
+            datatable (DataTable): The rendered datatable with parameters replaced only if they exist in the context.
         """
         if self.datatable:
             rendered_datatable = self.datatable


### PR DESCRIPTION
Render scenario names, docstrings and datatable cells with example table entries, just like step names currently are.

Fixed another issue that I hadn't seen before that background steps were also not able to be rendered using the current logic.  This is now fixed.

Resolves #741 
Resolves #252 
