### PR TITLE
Empty example table entries with converter to None documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -565,39 +565,6 @@ Example:
         assert datatable[1][1] in ["user1", "user2"]
 
 
-Rules
------
-
-In Gherkin, `Rules` allow you to group related scenarios or examples under a shared context.
-This is useful when you want to define different conditions or behaviours
-for multiple examples that follow a similar structure.
-You can use either ``Scenario`` or ``Example`` to define individual cases, as they are aliases and function identically.
-
-Additionally, **tags** applied to a rule will be automatically applied to all the **examples or scenarios**
-under that rule, making it easier to organize and filter tests during execution.
-
-Example:
-
-.. code-block:: gherkin
-
-    Feature: Rules and examples
-
-        @feature_tag
-        Rule: A rule for valid cases
-
-            @rule_tag
-            Example: Valid case 1
-                Given I have a valid input
-                When I process the input
-                Then the result should be successful
-
-        Rule: A rule for invalid cases
-            Example: Invalid case
-                Given I have an invalid input
-                When I process the input
-                Then the result should be an error
-
-
 Scenario Outlines with Multiple Example Tables
 ----------------------------------------------
 
@@ -661,6 +628,91 @@ only the examples under the "Positive results" table will be executed, and the "
 .. code-block:: bash
 
     pytest -k "positive"
+
+
+Handling Empty Example Cells
+----------------------------
+
+By default, empty cells in the example tables are interpreted as empty strings ("").
+However, there may be cases where it is more appropriate to handle them as ``None``.
+In such scenarios, you can use a converter with the ``parsers.re`` parser to define a custom behavior for empty values.
+
+For example, the following code demonstrates how to use a custom converter to return ``None`` when an empty cell is encountered:
+
+.. code-block:: gherkin
+
+    # content of empty_example_cells.feature
+
+    Feature: Handling empty example cells
+        Scenario Outline: Using converters for empty cells
+            Given I am starting lunch
+            Then there are <start> cucumbers
+
+            Examples:
+            | start |
+            |       |
+
+.. code-block:: python
+
+    from pytest_bdd import then, parsers
+
+
+    # Define a converter that returns None for empty strings
+    def empty_to_none(value):
+        return None if value.strip() == "" else value
+
+
+    @given("I am starting lunch")
+    def _():
+        pass
+
+
+    @then(
+        parsers.re("there are (?P<start>.*?) cucumbers"),
+        converters={"start": empty_to_none}
+    )
+    def _(start):
+        # Example assertion to demonstrate the conversion
+        assert start is None
+
+
+Here, the `start` cell in the example table is empty.
+When the ``parsers.re`` parser is combined with the ``empty_to_none`` converter,
+the empty cell will be converted to ``None`` and can be handled accordingly in the step definition.
+
+
+Rules
+-----
+
+In Gherkin, `Rules` allow you to group related scenarios or examples under a shared context.
+This is useful when you want to define different conditions or behaviours
+for multiple examples that follow a similar structure.
+You can use either ``Scenario`` or ``Example`` to define individual cases, as they are aliases and function identically.
+
+Additionally, **tags** applied to a rule will be automatically applied to all the **examples or scenarios**
+under that rule, making it easier to organize and filter tests during execution.
+
+Example:
+
+.. code-block:: gherkin
+
+    Feature: Rules and examples
+
+        @feature_tag
+        Rule: A rule for valid cases
+
+            @rule_tag
+            Example: Valid case 1
+                Given I have a valid input
+                When I process the input
+                Then the result should be successful
+
+        Rule: A rule for invalid cases
+
+            Example: Invalid case
+                Given I have an invalid input
+                When I process the input
+                Then the result should be an error
 
 
 Datatables

--- a/tests/feature/test_outline_empty_values.py
+++ b/tests/feature/test_outline_empty_values.py
@@ -4,6 +4,28 @@ import textwrap
 
 from pytest_bdd.utils import collect_dumped_objects
 
+STEPS = """\
+from pytest_bdd import given, when, then, parsers
+from pytest_bdd.utils import dump_obj
+
+# Using `parsers.re` so that we can match empty values
+
+@given(parsers.re("there are (?P<start>.*?) cucumbers"))
+def _(start):
+    dump_obj(start)
+
+
+@when(parsers.re("I eat (?P<eat>.*?) cucumbers"))
+def _(eat):
+    dump_obj(eat)
+
+
+@then(parsers.re("I should have (?P<left>.*?) cucumbers"))
+def _(left):
+    dump_obj(left)
+
+"""
+
 
 def test_scenario_with_empty_example_values(pytester):
     pytester.makefile(
@@ -22,36 +44,14 @@ def test_scenario_with_empty_example_values(pytester):
             """
         ),
     )
-    pytester.makeconftest(
-        textwrap.dedent(
-            """\
-            from pytest_bdd import given, when, then, parsers
-            from pytest_bdd.utils import dump_obj
-
-            # Using `parsers.re` so that we can match empty values
-
-            @given(parsers.re("there are (?P<start>.*?) cucumbers"))
-            def _(start):
-                dump_obj(start)
-
-
-            @when(parsers.re("I eat (?P<eat>.*?) cucumbers"))
-            def _(eat):
-                dump_obj(eat)
-
-
-            @then(parsers.re("I should have (?P<left>.*?) cucumbers"))
-            def _(left):
-                dump_obj(left)
-
-            """
-        )
-    )
+    pytester.makeconftest(textwrap.dedent(STEPS))
 
     pytester.makepyfile(
         textwrap.dedent(
             """\
+        from pytest_bdd.utils import dump_obj
         from pytest_bdd import scenario
+        import json
 
         @scenario("outline.feature", "Outlined with empty example values")
         def test_outline():
@@ -62,69 +62,3 @@ def test_scenario_with_empty_example_values(pytester):
     result = pytester.runpytest("-s")
     result.assert_outcomes(passed=1)
     assert collect_dumped_objects(result) == ["#", "", ""]
-
-
-def test_scenario_with_empty_example_values_none_transformer(pytester):
-    """
-    Checks that `parsers.re` can transform empty values to None with a converter.
-    `parsers.parse` and `parsers.cfparse` won't work out of the box this way as they will fail to match the steps.
-    """
-    pytester.makefile(
-        ".feature",
-        outline=textwrap.dedent(
-            """\
-            Feature: Outline
-                Scenario Outline: Outlined with empty example values and transformer
-                    Given there are <start> cucumbers
-                    When I eat <eat> cucumbers
-                    Then I should have <left> cucumbers
-
-                    Examples:
-                    | start | eat | left |
-                    | #     |     |      |
-            """
-        ),
-    )
-    pytester.makeconftest(
-        textwrap.dedent(
-            """\
-            from pytest_bdd import given, when, then, parsers
-            from pytest_bdd.utils import dump_obj
-
-
-            def empty_to_none(value):
-                return None if value.strip() == "" else value
-
-
-            @given(parsers.re("there are (?P<start>.*?) cucumbers"), converters={"start": empty_to_none})
-            def _(start):
-                dump_obj(start)
-
-
-            @when(parsers.re("I eat (?P<eat>.*?) cucumbers"), converters={"eat": empty_to_none})
-            def _(eat):
-                dump_obj(eat)
-
-
-            @then(parsers.re("I should have (?P<left>.*?) cucumbers"), converters={"left": empty_to_none})
-            def _(left):
-                dump_obj(left)
-
-            """
-        )
-    )
-
-    pytester.makepyfile(
-        textwrap.dedent(
-            """\
-            from pytest_bdd import scenario
-
-            @scenario("outline.feature", "Outlined with empty example values and transformer")
-            def test_outline():
-                pass
-            """
-        )
-    )
-    result = pytester.runpytest("-s")
-    result.assert_outcomes(passed=1)
-    assert collect_dumped_objects(result) == ["#", None, None]

--- a/tests/feature/test_outline_empty_values.py
+++ b/tests/feature/test_outline_empty_values.py
@@ -65,6 +65,10 @@ def test_scenario_with_empty_example_values(pytester):
 
 
 def test_scenario_with_empty_example_values_none_transformer(pytester):
+    """
+    Checks that `parsers.re` can transform empty values to None with a converter.
+    `parsers.parse` and `parsers.cfparse` won't work out of the box this way as they will fail to match the steps.
+    """
     pytester.makefile(
         ".feature",
         outline=textwrap.dedent(

--- a/tests/feature/test_outline_empty_values.py
+++ b/tests/feature/test_outline_empty_values.py
@@ -4,28 +4,6 @@ import textwrap
 
 from pytest_bdd.utils import collect_dumped_objects
 
-STEPS = """\
-from pytest_bdd import given, when, then, parsers
-from pytest_bdd.utils import dump_obj
-
-# Using `parsers.re` so that we can match empty values
-
-@given(parsers.re("there are (?P<start>.*?) cucumbers"))
-def _(start):
-    dump_obj(start)
-
-
-@when(parsers.re("I eat (?P<eat>.*?) cucumbers"))
-def _(eat):
-    dump_obj(eat)
-
-
-@then(parsers.re("I should have (?P<left>.*?) cucumbers"))
-def _(left):
-    dump_obj(left)
-
-"""
-
 
 def test_scenario_with_empty_example_values(pytester):
     pytester.makefile(
@@ -44,14 +22,36 @@ def test_scenario_with_empty_example_values(pytester):
             """
         ),
     )
-    pytester.makeconftest(textwrap.dedent(STEPS))
+    pytester.makeconftest(
+        textwrap.dedent(
+            """\
+            from pytest_bdd import given, when, then, parsers
+            from pytest_bdd.utils import dump_obj
+
+            # Using `parsers.re` so that we can match empty values
+
+            @given(parsers.re("there are (?P<start>.*?) cucumbers"))
+            def _(start):
+                dump_obj(start)
+
+
+            @when(parsers.re("I eat (?P<eat>.*?) cucumbers"))
+            def _(eat):
+                dump_obj(eat)
+
+
+            @then(parsers.re("I should have (?P<left>.*?) cucumbers"))
+            def _(left):
+                dump_obj(left)
+
+            """
+        )
+    )
 
     pytester.makepyfile(
         textwrap.dedent(
             """\
-        from pytest_bdd.utils import dump_obj
         from pytest_bdd import scenario
-        import json
 
         @scenario("outline.feature", "Outlined with empty example values")
         def test_outline():
@@ -62,3 +62,65 @@ def test_scenario_with_empty_example_values(pytester):
     result = pytester.runpytest("-s")
     result.assert_outcomes(passed=1)
     assert collect_dumped_objects(result) == ["#", "", ""]
+
+
+def test_scenario_with_empty_example_values_none_transformer(pytester):
+    pytester.makefile(
+        ".feature",
+        outline=textwrap.dedent(
+            """\
+            Feature: Outline
+                Scenario Outline: Outlined with empty example values and transformer
+                    Given there are <start> cucumbers
+                    When I eat <eat> cucumbers
+                    Then I should have <left> cucumbers
+
+                    Examples:
+                    | start | eat | left |
+                    | #     |     |      |
+            """
+        ),
+    )
+    pytester.makeconftest(
+        textwrap.dedent(
+            """\
+            from pytest_bdd import given, when, then, parsers
+            from pytest_bdd.utils import dump_obj
+
+
+            def empty_to_none(value):
+                return None if value.strip() == "" else value
+
+
+            @given(parsers.re("there are (?P<start>.*?) cucumbers"), converters={"start": empty_to_none})
+            def _(start):
+                dump_obj(start)
+
+
+            @when(parsers.re("I eat (?P<eat>.*?) cucumbers"), converters={"eat": empty_to_none})
+            def _(eat):
+                dump_obj(eat)
+
+
+            @then(parsers.re("I should have (?P<left>.*?) cucumbers"), converters={"left": empty_to_none})
+            def _(left):
+                dump_obj(left)
+
+            """
+        )
+    )
+
+    pytester.makepyfile(
+        textwrap.dedent(
+            """\
+            from pytest_bdd import scenario
+
+            @scenario("outline.feature", "Outlined with empty example values and transformer")
+            def test_outline():
+                pass
+            """
+        )
+    )
+    result = pytester.runpytest("-s")
+    result.assert_outcomes(passed=1)
+    assert collect_dumped_objects(result) == ["#", None, None]


### PR DESCRIPTION
Add documentation for parser converter for empty strings in example tables.

Resolves #551