### PR TITLE
Raise an error if a step defines reserved argument names (`datatable`, `docstring`)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,7 @@ Added
 
 Changed
 +++++++
+* Step arguments ``"datatable"`` and ``"docstring"`` are now reserved, and they can't be used as step argument names.
 
 Deprecated
 ++++++++++

--- a/src/pytest_bdd/exceptions.py
+++ b/src/pytest_bdd/exceptions.py
@@ -3,6 +3,10 @@
 from __future__ import annotations
 
 
+class StepImplementationError(Exception):
+    """Step implementation error."""
+
+
 class ScenarioIsDecoratorOnly(Exception):
     """Scenario can be only used as decorator."""
 

--- a/src/pytest_bdd/scenario.py
+++ b/src/pytest_bdd/scenario.py
@@ -175,7 +175,7 @@ def get_step_function(request: FixtureRequest, step: Step) -> StepFunctionContex
             return None
 
 
-def parse_step_arguments(step: Step, context: StepFunctionContext) -> dict[str, object] | None:
+def parse_step_arguments(step: Step, context: StepFunctionContext) -> dict[str, object]:
     """Parse step arguments."""
     parsed_args = context.parser.parse_arguments(step.name)
 

--- a/src/pytest_bdd/utils.py
+++ b/src/pytest_bdd/utils.py
@@ -83,3 +83,8 @@ def setdefault(obj: object, name: str, default: T) -> T:
     except AttributeError:
         setattr(obj, name, default)
         return default
+
+
+def identity(x: T) -> T:
+    """Return the argument."""
+    return x


### PR DESCRIPTION
Let's prevent headaches in the future and let's directly raise an error in case a step includes an argument like `datatable` or `docstring` that are also used to inject DataTable and Docstring objects.
