### PR TITLE
Add scenario description to JSON and add test for JSON correctly populating the description from a feature

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,7 @@ Added
 Changed
 +++++++
 * Step arguments ``"datatable"`` and ``"docstring"`` are now reserved, and they can't be used as step argument names.
+* Scenario ``description`` field is now set for JSON output
 
 Deprecated
 ++++++++++

--- a/src/pytest_bdd/cucumber_json.py
+++ b/src/pytest_bdd/cucumber_json.py
@@ -131,7 +131,7 @@ class LogBDDCucumberJSON:
                 "id": report.item["name"],
                 "name": scenario["name"],
                 "line": scenario["line_number"],
-                "description": "",
+                "description": scenario["description"],
                 "tags": self._serialize_tags(scenario),
                 "type": "scenario",
                 "steps": [stepmap(step) for step in scenario["steps"]],

--- a/src/pytest_bdd/reporting.py
+++ b/src/pytest_bdd/reporting.py
@@ -113,6 +113,7 @@ class ScenarioReport:
             "name": scenario.name,
             "line_number": scenario.line_number,
             "tags": sorted(scenario.tags),
+            "description": scenario.description,
             "feature": {
                 "keyword": feature.keyword,
                 "name": feature.name,

--- a/tests/feature/test_cucumber_json.py
+++ b/tests/feature/test_cucumber_json.py
@@ -55,6 +55,8 @@ def test_step_trace(pytester):
 
         @scenario-passing-tag
         Scenario: Passing
+            This is a scenario description
+
             Given a passing step
             And some other passing step
 
@@ -120,7 +122,7 @@ def test_step_trace(pytester):
             "description": "This is a feature description",
             "elements": [
                 {
-                    "description": "",
+                    "description": "This is a scenario description",
                     "id": "test_passing",
                     "keyword": "Scenario",
                     "line": 6,
@@ -128,14 +130,14 @@ def test_step_trace(pytester):
                     "steps": [
                         {
                             "keyword": "Given",
-                            "line": 7,
+                            "line": 9,
                             "match": {"location": ""},
                             "name": "a passing step",
                             "result": {"status": "passed", "duration": OfType(int)},
                         },
                         {
                             "keyword": "And",
-                            "line": 8,
+                            "line": 10,
                             "match": {"location": ""},
                             "name": "some other passing step",
                             "result": {"status": "passed", "duration": OfType(int)},
@@ -148,41 +150,41 @@ def test_step_trace(pytester):
                     "description": "",
                     "id": "test_failing",
                     "keyword": "Scenario",
-                    "line": 11,
+                    "line": 13,
                     "name": "Failing",
                     "steps": [
                         {
                             "keyword": "Given",
-                            "line": 12,
+                            "line": 14,
                             "match": {"location": ""},
                             "name": "a passing step",
                             "result": {"status": "passed", "duration": OfType(int)},
                         },
                         {
                             "keyword": "And",
-                            "line": 13,
+                            "line": 15,
                             "match": {"location": ""},
                             "name": "a failing step",
                             "result": {"error_message": OfType(str), "status": "failed", "duration": OfType(int)},
                         },
                     ],
-                    "tags": [{"name": "scenario-failing-tag", "line": 10}],
+                    "tags": [{"name": "scenario-failing-tag", "line": 12}],
                     "type": "scenario",
                 },
                 {
                     "description": "",
                     "keyword": "Scenario Outline",
-                    "tags": [{"line": 15, "name": "scenario-outline-passing-tag"}],
+                    "tags": [{"line": 17, "name": "scenario-outline-passing-tag"}],
                     "steps": [
                         {
-                            "line": 17,
+                            "line": 19,
                             "match": {"location": ""},
                             "result": {"status": "passed", "duration": OfType(int)},
                             "keyword": "Given",
                             "name": "type str and value hello",
                         }
                     ],
-                    "line": 16,
+                    "line": 18,
                     "type": "scenario",
                     "id": "test_passing_outline[str-hello]",
                     "name": "Passing outline",
@@ -190,17 +192,17 @@ def test_step_trace(pytester):
                 {
                     "description": "",
                     "keyword": "Scenario Outline",
-                    "tags": [{"line": 15, "name": "scenario-outline-passing-tag"}],
+                    "tags": [{"line": 17, "name": "scenario-outline-passing-tag"}],
                     "steps": [
                         {
-                            "line": 17,
+                            "line": 19,
                             "match": {"location": ""},
                             "result": {"status": "passed", "duration": OfType(int)},
                             "keyword": "Given",
                             "name": "type int and value 42",
                         }
                     ],
-                    "line": 16,
+                    "line": 18,
                     "type": "scenario",
                     "id": "test_passing_outline[int-42]",
                     "name": "Passing outline",
@@ -208,17 +210,17 @@ def test_step_trace(pytester):
                 {
                     "description": "",
                     "keyword": "Scenario Outline",
-                    "tags": [{"line": 15, "name": "scenario-outline-passing-tag"}],
+                    "tags": [{"line": 17, "name": "scenario-outline-passing-tag"}],
                     "steps": [
                         {
-                            "line": 17,
+                            "line": 19,
                             "match": {"location": ""},
                             "result": {"status": "passed", "duration": OfType(int)},
                             "keyword": "Given",
                             "name": "type float and value 1.0",
                         }
                     ],
-                    "line": 16,
+                    "line": 18,
                     "type": "scenario",
                     "id": "test_passing_outline[float-1.0]",
                     "name": "Passing outline",

--- a/tests/feature/test_cucumber_json.py
+++ b/tests/feature/test_cucumber_json.py
@@ -51,6 +51,7 @@ def test_step_trace(pytester):
             """
     @feature-tag
     Feature: One passing scenario, one failing scenario
+    This is a feature description
 
         @scenario-passing-tag
         Scenario: Passing
@@ -116,72 +117,72 @@ def test_step_trace(pytester):
     assert result.ret
     expected = [
         {
-            "description": "",
+            "description": "This is a feature description",
             "elements": [
                 {
                     "description": "",
                     "id": "test_passing",
                     "keyword": "Scenario",
-                    "line": 5,
+                    "line": 6,
                     "name": "Passing",
                     "steps": [
                         {
                             "keyword": "Given",
-                            "line": 6,
+                            "line": 7,
                             "match": {"location": ""},
                             "name": "a passing step",
                             "result": {"status": "passed", "duration": OfType(int)},
                         },
                         {
                             "keyword": "And",
-                            "line": 7,
+                            "line": 8,
                             "match": {"location": ""},
                             "name": "some other passing step",
                             "result": {"status": "passed", "duration": OfType(int)},
                         },
                     ],
-                    "tags": [{"name": "scenario-passing-tag", "line": 4}],
+                    "tags": [{"name": "scenario-passing-tag", "line": 5}],
                     "type": "scenario",
                 },
                 {
                     "description": "",
                     "id": "test_failing",
                     "keyword": "Scenario",
-                    "line": 10,
+                    "line": 11,
                     "name": "Failing",
                     "steps": [
                         {
                             "keyword": "Given",
-                            "line": 11,
+                            "line": 12,
                             "match": {"location": ""},
                             "name": "a passing step",
                             "result": {"status": "passed", "duration": OfType(int)},
                         },
                         {
                             "keyword": "And",
-                            "line": 12,
+                            "line": 13,
                             "match": {"location": ""},
                             "name": "a failing step",
                             "result": {"error_message": OfType(str), "status": "failed", "duration": OfType(int)},
                         },
                     ],
-                    "tags": [{"name": "scenario-failing-tag", "line": 9}],
+                    "tags": [{"name": "scenario-failing-tag", "line": 10}],
                     "type": "scenario",
                 },
                 {
                     "description": "",
                     "keyword": "Scenario Outline",
-                    "tags": [{"line": 14, "name": "scenario-outline-passing-tag"}],
+                    "tags": [{"line": 15, "name": "scenario-outline-passing-tag"}],
                     "steps": [
                         {
-                            "line": 16,
+                            "line": 17,
                             "match": {"location": ""},
                             "result": {"status": "passed", "duration": OfType(int)},
                             "keyword": "Given",
                             "name": "type str and value hello",
                         }
                     ],
-                    "line": 15,
+                    "line": 16,
                     "type": "scenario",
                     "id": "test_passing_outline[str-hello]",
                     "name": "Passing outline",
@@ -189,17 +190,17 @@ def test_step_trace(pytester):
                 {
                     "description": "",
                     "keyword": "Scenario Outline",
-                    "tags": [{"line": 14, "name": "scenario-outline-passing-tag"}],
+                    "tags": [{"line": 15, "name": "scenario-outline-passing-tag"}],
                     "steps": [
                         {
-                            "line": 16,
+                            "line": 17,
                             "match": {"location": ""},
                             "result": {"status": "passed", "duration": OfType(int)},
                             "keyword": "Given",
                             "name": "type int and value 42",
                         }
                     ],
-                    "line": 15,
+                    "line": 16,
                     "type": "scenario",
                     "id": "test_passing_outline[int-42]",
                     "name": "Passing outline",
@@ -207,17 +208,17 @@ def test_step_trace(pytester):
                 {
                     "description": "",
                     "keyword": "Scenario Outline",
-                    "tags": [{"line": 14, "name": "scenario-outline-passing-tag"}],
+                    "tags": [{"line": 15, "name": "scenario-outline-passing-tag"}],
                     "steps": [
                         {
-                            "line": 16,
+                            "line": 17,
                             "match": {"location": ""},
                             "result": {"status": "passed", "duration": OfType(int)},
                             "keyword": "Given",
                             "name": "type float and value 1.0",
                         }
                     ],
-                    "line": 15,
+                    "line": 16,
                     "type": "scenario",
                     "id": "test_passing_outline[float-1.0]",
                     "name": "Passing outline",

--- a/tests/feature/test_report.py
+++ b/tests/feature/test_report.py
@@ -117,6 +117,7 @@ def test_step_trace(pytester):
         "keyword": "Scenario",
         "line_number": 5,
         "name": "Passing",
+        "description": "",
         "steps": [
             {
                 "duration": OfType(float),
@@ -155,6 +156,7 @@ def test_step_trace(pytester):
         "keyword": "Scenario",
         "line_number": 10,
         "name": "Failing",
+        "description": "",
         "steps": [
             {
                 "duration": OfType(float),
@@ -192,6 +194,7 @@ def test_step_trace(pytester):
         "keyword": "Scenario Outline",
         "line_number": 14,
         "name": "Outlined",
+        "description": "",
         "steps": [
             {
                 "duration": OfType(float),
@@ -237,6 +240,7 @@ def test_step_trace(pytester):
         "keyword": "Scenario Outline",
         "line_number": 14,
         "name": "Outlined",
+        "description": "",
         "steps": [
             {
                 "duration": OfType(float),


### PR DESCRIPTION
Adds scenario description to json output.

The test for the json output didn't check the feature description field was populated.  I have added a value here so we can be sure this is being set.

Resolves #351 