### PR TITLE
Fix `null` returned in Cucumber JSON `scenario.description`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,7 @@ Removed
 
 Fixed
 +++++
+* Fixed regression introduced in version 8.1.0 where the Cucumber JSON output maybe have `scenario.description` set to `null` instead of the empty string. We now set it to the empty string as expected.
 
 Security
 ++++++++

--- a/src/pytest_bdd/reporting.py
+++ b/src/pytest_bdd/reporting.py
@@ -113,7 +113,7 @@ class ScenarioReport:
             "name": scenario.name,
             "line_number": scenario.line_number,
             "tags": sorted(scenario.tags),
-            "description": scenario.description,
+            "description": scenario.description or "",
             "feature": {
                 "keyword": feature.keyword,
                 "name": feature.name,


### PR DESCRIPTION
Fix regression of https://github.com/pytest-dev/pytest-bdd/pull/749 where we would serialize the `scenario.description` as `null` instead of the empty string.