### PR TITLE
Migrate `black`, `flake8`, `isort`, `pyupgrade` linters and formatters to `ruff`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,33 +1,16 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
--   repo: https://github.com/psf/black
-    # If you update the version here, also update it in tox.ini (py*-pytestlatest-linters)
-    rev: 24.10.0
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: cef0300fd0fc4d2a87a85fa2093c6b283ea36f4b  # frozen: v5.0.0
     hooks:
-    - id: black
--   repo: https://github.com/pycqa/isort
-    rev: 5.13.2
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-added-large-files
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: f0b5944bef86f50d875305821a0ab0d8c601e465  # frozen: v0.8.4
     hooks:
-      - id: isort
-        name: isort (python)
--   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
-    hooks:
-    -   id: trailing-whitespace
-    -   id: end-of-file-fixer
-    -   id: check-yaml
-    -   id: check-added-large-files
--   repo: https://github.com/asottile/pyupgrade
-    rev: v3.19.0
-    hooks:
-    -   id: pyupgrade
-        args: ["--py39-plus"]
--   repo: https://github.com/pycqa/flake8
-    rev: "7.1.1"
-    hooks:
-    -   id: flake8
-        additional_dependencies: [
-          "flake8-pyproject",
-          "flake8-bugbear",
-        ]
+      - id: ruff
+        args: [ --fix ]
+      - id: ruff-format

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "charliermarsh.ruff"
+    ]
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -5,6 +5,7 @@
 
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+from __future__ import annotations
 
 from importlib import metadata as _metadata
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,21 +57,25 @@ sphinx-autobuild = "*"
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
 
-[tool.black]
+[tool.ruff]
 line-length = 120
-target-version = ["py39", "py310", "py311", "py312", "py313"]
+target-version = "py39"
+lint.select = [
+    "B",  # flake8-bugbear
+    "E4",  # pycodestyle - error - import
+    "E7",  # pycodestyle - error - statement
+    "E9",  # pycodestyle - error - runtime
+    "F",  # pyflakes
+    "I",  # isort
+    "UP",  # pyupgrade
+]
+lint.isort.required-imports = [
+    "from __future__ import annotations",
+]
 
-[tool.flake8]
-# E1: indentation: already covered by `black`
-# E2: whitespace: already covered by `black`
-# E3: blank line: already covered by `black`
-# E501: line length: already covered by `black`
-extend-ignore = "E1,E2,E3,E501"
-
-[tool.isort]
-profile = "black"
-line_length = 120
-multi_line_output = 3
+[tool.ruff.lint.per-file-ignores]
+# Lint `I002` (required imports) for `from __future__ import annotations` in `src/`
+"!src/**.py" = ["I002"]
 
 [tool.coverage.report]
 exclude_lines = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,12 +62,15 @@ line-length = 120
 target-version = "py39"
 lint.select = [
     "B",     # flake8-bugbear
+    "BLE",   # flake8-blind-except
+    "C4",    # flake8-comprehensions
     "E4",    # pycodestyle - error - import
     "E7",    # pycodestyle - error - statement
     "E9",    # pycodestyle - error - runtime
     "F",     # pyflakes
     "I",     # isort
     "ISC",   # flake8-implicit-str-concat
+    "PERF",  # perflint
     "UP",    # pyupgrade
 ]
 lint.isort.required-imports = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,10 +73,6 @@ lint.isort.required-imports = [
     "from __future__ import annotations",
 ]
 
-[tool.ruff.lint.per-file-ignores]
-# Lint `I002` (required imports) for `from __future__ import annotations` in `src/`
-"!src/**.py" = ["I002"]
-
 [tool.coverage.report]
 exclude_lines = [
     "if TYPE_CHECKING:",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,13 +61,14 @@ build-backend = "poetry.core.masonry.api"
 line-length = 120
 target-version = "py39"
 lint.select = [
-    "B",   # flake8-bugbear
-    "E4",  # pycodestyle - error - import
-    "E7",  # pycodestyle - error - statement
-    "E9",  # pycodestyle - error - runtime
-    "F",   # pyflakes
-    "I",   # isort
-    "UP",  # pyupgrade
+    "B",     # flake8-bugbear
+    "E4",    # pycodestyle - error - import
+    "E7",    # pycodestyle - error - statement
+    "E9",    # pycodestyle - error - runtime
+    "F",     # pyflakes
+    "I",     # isort
+    "ISC",   # flake8-implicit-str-concat
+    "UP",    # pyupgrade
 ]
 lint.isort.required-imports = [
     "from __future__ import annotations",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,12 +61,12 @@ build-backend = "poetry.core.masonry.api"
 line-length = 120
 target-version = "py39"
 lint.select = [
-    "B",  # flake8-bugbear
+    "B",   # flake8-bugbear
     "E4",  # pycodestyle - error - import
     "E7",  # pycodestyle - error - statement
     "E9",  # pycodestyle - error - runtime
-    "F",  # pyflakes
-    "I",  # isort
+    "F",   # pyflakes
+    "I",   # isort
     "UP",  # pyupgrade
 ]
 lint.isort.required-imports = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,10 @@ lint.select = [
     "PERF",  # perflint
     "UP",    # pyupgrade
 ]
+lint.ignore = [
+    # Covered by formatter
+    "ISC001" # single-line-implicit-string-concatenation
+]
 lint.isort.required-imports = [
     "from __future__ import annotations",
 ]

--- a/src/pytest_bdd/gherkin_terminal_reporter.py
+++ b/src/pytest_bdd/gherkin_terminal_reporter.py
@@ -31,10 +31,9 @@ def configure(config: Config) -> None:
             raise Exception(
                 "gherkin-terminal-reporter is not compatible with any other terminal reporter."
                 "You can use only one terminal reporter."
-                "Currently '{0}' is used."
-                "Please decide to use one by deactivating {0} or gherkin-terminal-reporter.".format(
-                    current_reporter.__class__
-                )
+                f"Currently '{current_reporter.__class__}' is used."
+                f"Please decide to use one by deactivating {current_reporter.__class__} "
+                "or gherkin-terminal-reporter."
             )
         gherkin_reporter = GherkinTerminalReporter(config)
         config.pluginmanager.unregister(current_reporter)

--- a/src/pytest_bdd/parser.py
+++ b/src/pytest_bdd/parser.py
@@ -369,7 +369,7 @@ class FeatureParser:
         encoding (str): File encoding of the feature file to parse.
     """
 
-    def __init__(self, basedir: str, filename: str, encoding: str = "utf-8"):
+    def __init__(self, basedir: str, filename: str, encoding: str = "utf-8") -> None:
         self.abs_filename = os.path.abspath(os.path.join(basedir, filename))
         self.rel_filename = os.path.join(os.path.basename(basedir), filename)
         self.encoding = encoding

--- a/src/pytest_bdd/parser.py
+++ b/src/pytest_bdd/parser.py
@@ -10,14 +10,12 @@ from dataclasses import dataclass, field
 
 from .exceptions import StepError
 from .gherkin_parser import Background as GherkinBackground
-from .gherkin_parser import DataTable
+from .gherkin_parser import DataTable, GherkinDocument, get_gherkin_document
 from .gherkin_parser import Feature as GherkinFeature
-from .gherkin_parser import GherkinDocument
 from .gherkin_parser import Rule as GherkinRule
 from .gherkin_parser import Scenario as GherkinScenario
 from .gherkin_parser import Step as GherkinStep
 from .gherkin_parser import Tag as GherkinTag
-from .gherkin_parser import get_gherkin_document
 from .types import STEP_TYPE_BY_PARSER_KEYWORD
 
 PARAM_RE = re.compile(r"<(.+?)>")

--- a/src/pytest_bdd/parser.py
+++ b/src/pytest_bdd/parser.py
@@ -46,7 +46,7 @@ def get_tag_names(tag_data: list[GherkinTag]) -> set[str]:
     """Extract tag names from tag data.
 
     Args:
-        tag_data (List[dict]): The tag data to extract names from.
+        tag_data (list[dict]): The tag data to extract names from.
 
     Returns:
         set[str]: A set of tag names.
@@ -64,7 +64,7 @@ class Feature:
         rel_filename (str): The relative path of the feature file.
         name (str): The name of the feature.
         tags (set[str]): A set of tags associated with the feature.
-        background (Optional[Background]): The background steps for the feature, if any.
+        background (Background | None): The background steps for the feature, if any.
         line_number (int): The line number where the feature starts in the file.
         description (str): The description of the feature.
     """
@@ -86,10 +86,10 @@ class Examples:
     """Represents examples used in scenarios for parameterization.
 
     Attributes:
-        line_number (Optional[int]): The line number where the examples start.
-        name (Optional[str]): The name of the examples.
-        example_params (List[str]): The names of the parameters for the examples.
-        examples (List[Sequence[str]]): The list of example rows.
+        line_number (int | None): The line number where the examples start.
+        name (str | None): The name of the examples.
+        example_params (list[str]): The names of the parameters for the examples.
+        examples (list[Sequence[str]]): The list of example rows.
     """
 
     line_number: int | None = None
@@ -152,11 +152,11 @@ class ScenarioTemplate:
         name (str): The name of the scenario.
         line_number (int): The line number where the scenario starts in the file.
         templated (bool): Whether the scenario is templated.
-        description (Optional[str]): The description of the scenario.
+        description (str | None): The description of the scenario.
         tags (set[str]): A set of tags associated with the scenario.
-        _steps (List[Step]): The list of steps in the scenario (internal use only).
-        examples (Optional[Examples]): The examples used for parameterization in the scenario.
-        rule (Optional[Rule]): The rule to which the scenario may belong (None = no rule).
+        _steps (list[Step]): The list of steps in the scenario (internal use only).
+        examples (Examples | None): The examples used for parameterization in the scenario.
+        rule (Rule | None): The rule to which the scenario may belong (None = no rule).
     """
 
     feature: Feature
@@ -195,7 +195,7 @@ class ScenarioTemplate:
         """Get all steps for the scenario, including background steps.
 
         Returns:
-            List[Step]: A list of steps, including any background steps from the feature.
+            list[Step]: A list of steps, including any background steps from the feature.
         """
         return self.all_background_steps + self._steps
 
@@ -242,8 +242,8 @@ class Scenario:
         keyword (str): The keyword used to define the scenario.
         name (str): The name of the scenario.
         line_number (int): The line number where the scenario starts in the file.
-        steps (List[Step]): The list of steps in the scenario.
-        description (Optional[str]): The description of the scenario.
+        steps (list[Step]): The list of steps in the scenario.
+        description (str | None): The description of the scenario.
         tags (set[str]): A set of tags associated with the scenario.
     """
 
@@ -268,8 +268,8 @@ class Step:
         indent (int): The indentation level of the step.
         keyword (str): The keyword used for the step (e.g., 'Given', 'When', 'Then').
         failed (bool): Whether the step has failed (internal use only).
-        scenario (Optional[ScenarioTemplate]): The scenario to which this step belongs (internal use only).
-        background (Optional[Background]): The background to which this step belongs (internal use only).
+        scenario (ScenarioTemplate | None): The scenario to which this step belongs (internal use only).
+        background (Background | None): The background to which this step belongs (internal use only).
     """
 
     type: str
@@ -344,7 +344,7 @@ class Background:
 
     Attributes:
         line_number (int): The line number where the background starts in the file.
-        steps (List[Step]): The list of steps in the background.
+        steps (list[Step]): The list of steps in the background.
     """
 
     line_number: int
@@ -378,10 +378,10 @@ class FeatureParser:
         """Parse a list of step data into Step objects.
 
         Args:
-            steps_data (List[dict]): The list of step data.
+            steps_data (list[dict]): The list of step data.
 
         Returns:
-            List[Step]: A list of Step objects.
+            list[Step]: A list of Step objects.
         """
 
         if not steps_data:
@@ -421,7 +421,7 @@ class FeatureParser:
         Args:
             scenario_data (dict): The dictionary containing scenario data.
             feature (Feature): The feature to which this scenario belongs.
-            rule (Optional[Rule]): The rule to which this scenario may belong. (None = no rule)
+            rule (Rule | None): The rule to which this scenario may belong. (None = no rule)
 
         Returns:
             ScenarioTemplate: A ScenarioTemplate object representing the parsed scenario.

--- a/src/pytest_bdd/scenario.py
+++ b/src/pytest_bdd/scenario.py
@@ -384,7 +384,7 @@ def scenario(
         scenario = feature.scenarios[scenario_name]
     except KeyError:
         feature_name = feature.name or "[Empty]"
-        raise exceptions.ScenarioNotFound(
+        raise exceptions.ScenarioNotFound(  # noqa: B904
             f'Scenario "{scenario_name}" in feature "{feature_name}" in {feature.filename} is not found.'
         )
 

--- a/src/pytest_bdd/scenario.py
+++ b/src/pytest_bdd/scenario.py
@@ -188,9 +188,9 @@ def parse_step_arguments(step: Step, context: StepFunctionContext) -> dict[str, 
     """Parse step arguments."""
     parsed_args = context.parser.parse_arguments(step.name)
 
-    assert parsed_args is not None, (
-        f"Unexpected `NoneType` returned from " f"parse_arguments(...) in parser: {context.parser!r}"
-    )
+    assert (
+        parsed_args is not None
+    ), f"Unexpected `NoneType` returned from parse_arguments(...) in parser: {context.parser!r}"
 
     reserved_args = set(parsed_args.keys()) & STEP_ARGUMENTS_RESERVED_NAMES
     if reserved_args:

--- a/src/pytest_bdd/scenario.py
+++ b/src/pytest_bdd/scenario.py
@@ -384,9 +384,9 @@ def scenario(
         scenario = feature.scenarios[scenario_name]
     except KeyError:
         feature_name = feature.name or "[Empty]"
-        raise exceptions.ScenarioNotFound(  # noqa: B904
+        raise exceptions.ScenarioNotFound(
             f'Scenario "{scenario_name}" in feature "{feature_name}" in {feature.filename} is not found.'
-        )
+        ) from None
 
     return _get_scenario_decorator(
         feature=feature, feature_name=feature_name, templated_scenario=scenario, scenario_name=scenario_name

--- a/tests/args/cfparse/test_args.py
+++ b/tests/args/cfparse/test_args.py
@@ -1,5 +1,7 @@
 """Step arguments tests."""
 
+from __future__ import annotations
+
 import textwrap
 
 

--- a/tests/args/parse/test_args.py
+++ b/tests/args/parse/test_args.py
@@ -1,5 +1,7 @@
 """Step arguments tests."""
 
+from __future__ import annotations
+
 import textwrap
 
 

--- a/tests/args/regex/test_args.py
+++ b/tests/args/regex/test_args.py
@@ -1,5 +1,7 @@
 """Step arguments tests."""
 
+from __future__ import annotations
+
 import textwrap
 
 

--- a/tests/args/test_common.py
+++ b/tests/args/test_common.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import textwrap
 
 from pytest_bdd.utils import collect_dumped_objects

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 pytest_plugins = "pytester"

--- a/tests/datatable/test_datatable.py
+++ b/tests/datatable/test_datatable.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import textwrap
 
 from src.pytest_bdd.utils import collect_dumped_objects

--- a/tests/feature/test_alias.py
+++ b/tests/feature/test_alias.py
@@ -1,5 +1,7 @@
 """Test step alias when decorated multiple times."""
 
+from __future__ import annotations
+
 import textwrap
 
 

--- a/tests/feature/test_background.py
+++ b/tests/feature/test_background.py
@@ -1,5 +1,7 @@
 """Test feature background."""
 
+from __future__ import annotations
+
 import textwrap
 
 FEATURE = '''\

--- a/tests/feature/test_description.py
+++ b/tests/feature/test_description.py
@@ -1,5 +1,7 @@
 """Test descriptions."""
 
+from __future__ import annotations
+
 import textwrap
 
 

--- a/tests/feature/test_feature_base_dir.py
+++ b/tests/feature/test_feature_base_dir.py
@@ -1,5 +1,7 @@
 """Test feature base dir."""
 
+from __future__ import annotations
+
 import os
 
 import pytest

--- a/tests/feature/test_feature_base_dir.py
+++ b/tests/feature/test_feature_base_dir.py
@@ -59,12 +59,10 @@ def test_feature_path_by_param_ok(pytester, base_dir):
 
 def prepare_testdir(pytester, ini_base_dir):
     pytester.makeini(
-        """
+        f"""
             [pytest]
-            bdd_features_base_dir={}
-        """.format(
-            ini_base_dir
-        )
+            bdd_features_base_dir={ini_base_dir}
+        """
     )
 
     feature_file = pytester.mkdir("features").joinpath("steps.feature")
@@ -77,7 +75,7 @@ def prepare_testdir(pytester, ini_base_dir):
     )
 
     pytester.makepyfile(
-        """
+        f"""
     import os.path
 
     import pytest
@@ -103,7 +101,7 @@ def prepare_testdir(pytester, ini_base_dir):
                 scenarios(FEATURE)
             else:
                 scenario(FEATURE, scenario_name)
-        assert os.path.abspath(os.path.join('{}', FEATURE)) in str(exc.value)
+        assert os.path.abspath(os.path.join('{ini_base_dir}', FEATURE)) in str(exc.value)
 
 
     @pytest.mark.parametrize(
@@ -145,7 +143,5 @@ def prepare_testdir(pytester, ini_base_dir):
         else:
             scenario(FEATURE, scenario_name, features_base_dir='features')
 
-    """.format(
-            ini_base_dir
-        )
+    """
     )

--- a/tests/feature/test_gherkin_terminal_reporter.py
+++ b/tests/feature/test_gherkin_terminal_reporter.py
@@ -200,9 +200,7 @@ def test_step_parameters_should_be_replaced_by_their_values(pytester):
             Examples:
             | start | eat | left |
             |{start}|{eat}|{left}|
-        """.format(
-                **example
-            )
+        """.format(**example)
         ),
     )
     pytester.makepyfile(

--- a/tests/feature/test_no_scenario.py
+++ b/tests/feature/test_no_scenario.py
@@ -1,5 +1,7 @@
 """Test no scenarios defined in the feature file."""
 
+from __future__ import annotations
+
 import textwrap
 
 

--- a/tests/feature/test_outline.py
+++ b/tests/feature/test_outline.py
@@ -335,7 +335,7 @@ def test_variable_reuse(pytester):
         outline=textwrap.dedent(
             """\
             Feature: Example parameters reuse
-                Scenario Outline: Check for example parameter re-use
+                Scenario Outline: Check for example parameter reuse
                     Given the param is initially set from the example table as <param>
                     When a step arg of the same name is set to "other"
                     Then the param is still set from the example table as <param>

--- a/tests/feature/test_outline.py
+++ b/tests/feature/test_outline.py
@@ -1,5 +1,7 @@
 """Scenario Outline tests."""
 
+from __future__ import annotations
+
 import textwrap
 
 from pytest_bdd.utils import collect_dumped_objects

--- a/tests/feature/test_outline_empty_values.py
+++ b/tests/feature/test_outline_empty_values.py
@@ -1,5 +1,7 @@
 """Scenario Outline with empty example values tests."""
 
+from __future__ import annotations
+
 import textwrap
 
 from pytest_bdd.utils import collect_dumped_objects

--- a/tests/feature/test_report.py
+++ b/tests/feature/test_report.py
@@ -1,7 +1,8 @@
 """Test scenario reporting."""
 
+from __future__ import annotations
+
 import textwrap
-from typing import Optional
 
 import pytest
 
@@ -11,7 +12,7 @@ from pytest_bdd.reporting import test_report_context_registry
 class OfType:
     """Helper object comparison to which is always 'equal'."""
 
-    def __init__(self, type: Optional[type] = None) -> None:
+    def __init__(self, type: type | None = None) -> None:
         self.type = type
 
     def __eq__(self, other: object) -> bool:

--- a/tests/feature/test_rule_example_format.py
+++ b/tests/feature/test_rule_example_format.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import textwrap
 
 

--- a/tests/feature/test_same_function_name.py
+++ b/tests/feature/test_same_function_name.py
@@ -1,5 +1,7 @@
 """Function name same as step name."""
 
+from __future__ import annotations
+
 import textwrap
 
 

--- a/tests/feature/test_scenario.py
+++ b/tests/feature/test_scenario.py
@@ -1,5 +1,7 @@
 """Test scenario decorator."""
 
+from __future__ import annotations
+
 import textwrap
 
 from pytest_bdd.utils import collect_dumped_objects

--- a/tests/feature/test_scenarios.py
+++ b/tests/feature/test_scenarios.py
@@ -1,5 +1,7 @@
 """Test scenarios shortcut."""
 
+from __future__ import annotations
+
 import textwrap
 
 

--- a/tests/feature/test_steps.py
+++ b/tests/feature/test_steps.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import textwrap
 
 

--- a/tests/feature/test_tags.py
+++ b/tests/feature/test_tags.py
@@ -1,5 +1,7 @@
 """Test tags."""
 
+from __future__ import annotations
+
 import textwrap
 
 

--- a/tests/feature/test_wrong.py
+++ b/tests/feature/test_wrong.py
@@ -1,5 +1,7 @@
 """Test wrong feature syntax."""
 
+from __future__ import annotations
+
 import textwrap
 
 

--- a/tests/generation/test_generate_missing.py
+++ b/tests/generation/test_generate_missing.py
@@ -1,5 +1,7 @@
 """Code generation and assertion tests."""
 
+from __future__ import annotations
+
 import itertools
 import textwrap
 

--- a/tests/library/test_parent.py
+++ b/tests/library/test_parent.py
@@ -3,6 +3,8 @@
 Check the parent givens are collected and overridden in the local conftest.
 """
 
+from __future__ import annotations
+
 import textwrap
 
 from pytest_bdd.utils import collect_dumped_objects

--- a/tests/library/test_parent.py
+++ b/tests/library/test_parent.py
@@ -235,7 +235,7 @@ def test_local(pytester):
 
 def test_uses_correct_step_in_the_hierarchy(pytester):
     """
-    Test regression found in issue #524, where we couldn't find the correct step implemntation in the
+    Test regression found in issue #524, where we couldn't find the correct step implementation in the
     hierarchy of files/folder as expected.
     This test uses many files and folders that act as decoy, while the real step implementation is defined
     in the last file (test_b/test_b.py).

--- a/tests/parser/test_errors.py
+++ b/tests/parser/test_errors.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import textwrap
 
 

--- a/tests/parser/test_parser.py
+++ b/tests/parser/test_parser.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pathlib import Path
 
 from src.pytest_bdd.gherkin_parser import (

--- a/tests/scripts/test_generate.py
+++ b/tests/scripts/test_generate.py
@@ -1,5 +1,7 @@
 """Test code generation command."""
 
+from __future__ import annotations
+
 import os
 import sys
 import textwrap

--- a/tests/scripts/test_main.py
+++ b/tests/scripts/test_main.py
@@ -1,5 +1,7 @@
 """Main command."""
 
+from __future__ import annotations
+
 import os
 import sys
 import textwrap

--- a/tests/scripts/test_migrate.py
+++ b/tests/scripts/test_migrate.py
@@ -1,5 +1,7 @@
 """Test code generation command."""
 
+from __future__ import annotations
+
 import os
 import sys
 import textwrap
@@ -31,11 +33,7 @@ def test_migrate(monkeypatch, capsys, pytester):
     expected = textwrap.dedent(
         """
     migrated: {0}/test_foo.py
-    skipped: {0}/__init__.py""".format(
-            str(tests)
-        )[
-            1:
-        ]
+    skipped: {0}/__init__.py""".format(str(tests))[1:]
     )
     assert out == expected
     assert tests.joinpath("test_foo.py").read_text() == textwrap.dedent(

--- a/tests/steps/test_common.py
+++ b/tests/steps/test_common.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import textwrap
 from typing import Any, Callable
 from unittest import mock

--- a/tests/steps/test_docstring.py
+++ b/tests/steps/test_docstring.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import textwrap
 
 from src.pytest_bdd.utils import collect_dumped_objects

--- a/tests/steps/test_given.py
+++ b/tests/steps/test_given.py
@@ -1,5 +1,7 @@
 """Given tests."""
 
+from __future__ import annotations
+
 import textwrap
 
 

--- a/tests/steps/test_keyword.py
+++ b/tests/steps/test_keyword.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import textwrap
 
 

--- a/tests/steps/test_unicode.py
+++ b/tests/steps/test_unicode.py
@@ -1,5 +1,7 @@
 """Tests for testing cases when we have unicode in feature file."""
 
+from __future__ import annotations
+
 import textwrap
 
 

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import textwrap
 
 from pytest_bdd.utils import collect_dumped_objects


### PR DESCRIPTION
### 🤔 What's changed?

- Migrated linters [`flake8`](https://flake8.pycqa.org/), [`isort`](https://pycqa.github.io/isort/), [`pydocstyle`](https://pycodestyle.pycqa.org/en/latest/) and [`pyupgrade`](https://github.com/asottile/pyupgrade) to [`ruff`](https://docs.astral.sh/ruff)
- Migrated formatter [`black`](https://black.readthedocs.io/en/stable/) to `ruff`
- Froze pre-commit dependency versions to commit hashes
- Applied and enforced `from __future__ import annotations` on all Python modules
- Updated docstring type hints to match `__future__.annotations` syntax e.g. `List` to `list`, `Optional` to `... | None`
- Applied [`codespell`](https://pypi.org/project/codespell/1.9.1/) spelling corrections

### ⚡️ What's your motivation? 

- Migrating to ruff provides the following enhancements:
  - ⚡️Extremely fast - 42x faster than flake8 in ruff's benchmark - and even faster with built-in caching
    - See pytest-bdd pre-commit run [_before_ (4.6s)](https://results.pre-commit.ci/run/github/9094192/1733662754.3Alsch-XRqe7VDtJavRIJA) and [_after_ (2.6s)](https://results.pre-commit.ci/run/github/9094192/1735768054.FREynhL-TBSpUE7ADGxgJA)
  - 📏 [Hundreds of additional linting rules](https://docs.astral.sh/ruff/rules)
  - 🐁 Reduces linting and formatting dependencies (`black`, `flake8`, `flake8-bugbear`, `flake8-pyproject`, `mccabe`, `pycodestyle`, `pyflakes`, `isort`, `pyupgrade`, `tokenize-rt`) down to `ruff` - including "Drop-in parity with flake8, isort, and black"
  - 🔧 Fix support, for automatic error correction
  - ⌨️ First-party [editor integrations](https://docs.astral.sh/ruff/integrations/) for [VS Code](https://github.com/astral-sh/ruff-vscode) and [more](https://docs.astral.sh/ruff/editors/setup/)
  - 🛠️ Native `pyproject.toml` support - without requiring dependencies such as `flake8-pyproject` - and can be read by IDE extensions and is monorepo-friendly, with [hierarchical and cascading configuration](https://docs.astral.sh/ruff/configuration/#config-file-discovery). Centralises configuration rather than splitting across pre-commit, pyproject.toml, IDE settings, etc.
  - 🤝 Simplifies contributing experience and running linting and formatting locally or through developer tools
- [pytest has adopted ruff](https://github.com/pytest-dev/pytest/pull/11901) 
- Appears to be at least [some level of ruff adoption amongst pytest-bdd contributors](https://github.com/pytest-dev/pytest-bdd/pull/653#discussion_r1394971473)
- Freezing pre-commit hashes is better for security (matches cucumber/gherkin#326)

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)

### ♻️ Anything particular you want feedback on?

- Whether suitable to include a recommended VSCode workspace extension or should omit

### References

- [flake8 error codes](https://flake8.pycqa.org/en/latest/user/error-codes.html)
- [pycodestyle error codes](https://pycodestyle.pycqa.org/en/latest/intro.html#error-codes) (installed with flake8)
- [ruff rules](https://docs.astral.sh/ruff/rules)