### PR TITLE
Add `.envrc` that loads poetry virtualenv

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,17 @@
+# config file for `direnv`: https://direnv.net
+# load the poetry virtual environment when entering the project directory
+
+strict_env
+
+if [[ ! -f "pyproject.toml" ]]; then
+  log_error 'No pyproject.toml found. Use `poetry new` or `poetry init` to create one first.'
+  exit 2
+fi
+
+local VENV="$(poetry env info --path)"
+if [[ -z $VENV || ! -d $VENV/bin ]]; then
+  log_error 'No poetry virtual environment found. Use `poetry install` to create one first.'
+  exit 2
+fi
+
+source_env "$VENV/bin/activate"


### PR DESCRIPTION
Add `.envrc` (used by `direnv` tool), so that the poetry virtualenv is loaded automatically when entering the project directory. 