### PR TITLE
Remove internal pytest functions from displayed traceback on step failure

### DIFF
--- a/tests/feature/test_gherkin_terminal_reporter.py
+++ b/tests/feature/test_gherkin_terminal_reporter.py
@@ -181,7 +181,6 @@ def test_local_variables_should_be_displayed_when_showlocals_option_is_used(pyte
     )
     result = pytester.runpytest("--gherkin-terminal-reporter", "--showlocals")
     result.assert_outcomes(passed=0, failed=1)
-    result.stdout.fnmatch_lines("""request*=*<FixtureRequest for *""")
     result.stdout.fnmatch_lines("""local_var*=*MULTIPASS*""")
 
 


### PR DESCRIPTION
This change removes the stack trace of `call_fixture_func` from the output when a test fails:

```gherkin
# contents of example.feature
Feature: Test
    Scenario: Test
        Given foo
```
```python
# contents of test_example.py
from pytest_bdd import scenario, given

@scenario("example.feature", "Test")
def test_example():
    pass

@given("foo")
def foo():
    assert 1 == 2
```

# Before

```console
$ pytest
=================================== test session starts ====================================
platform linux -- Python 3.10.12, pytest-8.3.4, pluggy-1.5.0
rootdir: /home/ben/scratch/example
plugins: bdd-8.1.0
collected 1 item

test_example.py F                                                                    [100%]

========================================= FAILURES =========================================
_______________________________________ test_example _______________________________________

fixturefunc = <function foo at 0x7f7db80b9f30>
request = <FixtureRequest for <Function test_example>>, kwargs = {}

    def call_fixture_func(
        fixturefunc: _FixtureFunc[FixtureValue], request: FixtureRequest, kwargs
    ) -> FixtureValue:
        if is_generator(fixturefunc):
            fixturefunc = cast(
                Callable[..., Generator[FixtureValue, None, None]], fixturefunc
            )
            generator = fixturefunc(**kwargs)
            try:
                fixture_result = next(generator)
            except StopIteration:
                raise ValueError(f"{request.fixturename} did not yield a value") from None
            finalizer = functools.partial(_teardown_yield_fixture, fixturefunc, generator)
            request.addfinalizer(finalizer)
        else:
            fixturefunc = cast(Callable[..., FixtureValue], fixturefunc)
>           fixture_result = fixturefunc(**kwargs)

venv/lib/python3.10/site-packages/_pytest/fixtures.py:898:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

    @given("foo")
    def foo():
>       assert 1 == 2
E       assert 1 == 2

test_example.py:10: AssertionError
================================= short test summary info ==================================
FAILED test_example.py::test_example - assert 1 == 2
==================================== 1 failed in 0.02s =====================================
```

# After

```console
$ pytest
=================================== test session starts ====================================
platform linux -- Python 3.10.12, pytest-8.3.4, pluggy-1.5.0
rootdir: /home/ben/scratch/example
plugins: bdd-8.1.0, xdist-3.6.1, anyio-4.7.0
collected 1 item

test_example.py F                                                                    [100%]

========================================= FAILURES =========================================
_______________________________________ test_example _______________________________________

    @given("foo")
    def foo():
>       assert 1 == 2
E       assert 1 == 2

test_example.py:10: AssertionError
================================= short test summary info ==================================
FAILED test_example.py::test_example - assert 1 == 2
==================================== 1 failed in 0.04s =====================================
```
