### PR TITLE
Use scenarios shortcut in generated tests

### DIFF
--- a/src/pytest_bdd/templates/test.py.mak
+++ b/src/pytest_bdd/templates/test.py.mak
@@ -3,17 +3,15 @@
 
 from pytest_bdd import (
     given,
-    scenario,
+    scenarios,
     then,
     when,
 )
 
 
 % endif
-% for scenario in sorted(scenarios, key=lambda scenario: scenario.name):
-@scenario('${scenario.feature.rel_filename}', ${ make_string_literal(scenario.name)})
-def test_${ make_python_name(scenario.name)}():
-    ${make_python_docstring(scenario.name)}
+% for feature in dict.fromkeys(scenario.feature for scenario in scenarios):
+scenarios(${ make_string_literal(feature.rel_filename.replace("\\", "/"))})
 
 
 % endfor

--- a/tests/scripts/test_generate.py
+++ b/tests/scripts/test_generate.py
@@ -42,15 +42,13 @@ def test_generate(pytester, monkeypatch, capsys):
 
     from pytest_bdd import (
         given,
-        scenario,
+        scenarios,
         then,
         when,
     )
 
 
-    @scenario('scripts/generate.feature', 'Given and when using the same fixture should not evaluate it twice')
-    def test_given_and_when_using_the_same_fixture_should_not_evaluate_it_twice():
-        """Given and when using the same fixture should not evaluate it twice."""
+    scenarios('scripts/generate.feature')
 
 
     @given('1 have a fixture (appends 1 to a list) in reuse syntax')
@@ -108,15 +106,13 @@ def test_generate_with_quotes(pytester):
 
     from pytest_bdd import (
         given,
-        scenario,
+        scenarios,
         then,
         when,
     )
 
 
-    @scenario('generate_with_quotes.feature', 'A step definition with quotes should be escaped as needed')
-    def test_a_step_definition_with_quotes_should_be_escaped_as_needed():
-        """A step definition with quotes should be escaped as needed."""
+    scenarios('generate_with_quotes.feature')
 
 
     @given('I have a fixture with "double" quotes')
@@ -184,15 +180,13 @@ def test_unicode_characters(pytester, monkeypatch):
 
             from pytest_bdd import (
                 given,
-                scenario,
+                scenarios,
                 then,
                 when,
             )
 
 
-            @scenario('unicode_characters.feature', 'Calculating the circumference of a circle')
-            def test_calculating_the_circumference_of_a_circle():
-                """Calculating the circumference of a circle."""
+            scenarios('unicode_characters.feature')
 
 
             @given('We have a circle')


### PR DESCRIPTION
Fixes #535.

This updates the generated test template to use `scenarios(...)` once per feature instead of emitting a separate `@scenario(...)` wrapper for each scenario. The generated step definitions stay the same.

Also updated the generator tests to match the new output.