### PR TITLE
Fix pytest.fail() not captured in cucumber JSON step output

### DIFF
--- a/src/pytest_bdd/scenario.py
+++ b/src/pytest_bdd/scenario.py
@@ -24,6 +24,7 @@ from weakref import WeakKeyDictionary
 
 import pytest
 from _pytest.fixtures import FixtureDef, FixtureManager, FixtureRequest, call_fixture_func
+from _pytest.outcomes import Failed
 
 from . import exceptions
 from .compat import getfixturedefs, inject_fixture
@@ -247,7 +248,7 @@ def _execute_step_function(
         # so that we can allow "yield" statements in it
         return_value = call_fixture_func(fixturefunc=context.step_func, request=request, kwargs=kwargs)
 
-    except BaseException as exception:
+    except (Exception, Failed) as exception:
         request.config.hook.pytest_bdd_step_error(exception=exception, **kw)
         raise
 

--- a/src/pytest_bdd/scenario.py
+++ b/src/pytest_bdd/scenario.py
@@ -247,7 +247,7 @@ def _execute_step_function(
         # so that we can allow "yield" statements in it
         return_value = call_fixture_func(fixturefunc=context.step_func, request=request, kwargs=kwargs)
 
-    except Exception as exception:
+    except BaseException as exception:
         request.config.hook.pytest_bdd_step_error(exception=exception, **kw)
         raise
 

--- a/tests/feature/test_cucumber_json.py
+++ b/tests/feature/test_cucumber_json.py
@@ -240,7 +240,7 @@ def test_step_trace(pytester):
 
 
 def test_pytest_fail_in_step_body(pytester):
-    """pytest.fail() raised directly inside a step body is captured as failed in the JSON."""
+    """Test that pytest.fail() in a step body is captured as failed in the JSON output."""
     pytester.makefile(
         ".feature",
         test=textwrap.dedent(
@@ -282,7 +282,7 @@ def test_pytest_fail_in_step_body(pytester):
 
 
 def test_pytest_fail_in_fixture(pytester):
-    """pytest.fail() raised in a fixture used by a step is captured as failed in the JSON."""
+    """Test that pytest.fail() in a fixture used by a step is captured as failed in the JSON output."""
     pytester.makefile(
         ".feature",
         test=textwrap.dedent(

--- a/tests/feature/test_cucumber_json.py
+++ b/tests/feature/test_cucumber_json.py
@@ -237,3 +237,91 @@ def test_step_trace(pytester):
     ]
 
     assert jsonobject == expected
+
+
+def test_pytest_fail_in_step_body(pytester):
+    """pytest.fail() raised directly inside a step body is captured as failed in the JSON."""
+    pytester.makefile(
+        ".feature",
+        test=textwrap.dedent(
+            """
+    Feature: Failing via pytest.fail in step body
+        Scenario: Fail in step body
+            Given a passing step
+            And a step that calls pytest.fail
+    """
+        ),
+    )
+    pytester.makepyfile(
+        textwrap.dedent(
+            """
+        import pytest
+        from pytest_bdd import given, scenario
+
+        @given('a passing step')
+        def _():
+            pass
+
+        @given('a step that calls pytest.fail')
+        def _():
+            pytest.fail('deliberate failure')
+
+        @scenario('test.feature', 'Fail in step body')
+        def test_scenario():
+            pass
+    """
+        )
+    )
+    result, jsonobject = runandparse(pytester)
+    result.assert_outcomes(failed=1)
+
+    steps = jsonobject[0]["elements"][0]["steps"]
+    assert steps[0]["result"]["status"] == "passed"
+    assert steps[1]["result"]["status"] == "failed"
+    assert "deliberate failure" in steps[1]["result"]["error_message"]
+
+
+def test_pytest_fail_in_fixture(pytester):
+    """pytest.fail() raised in a fixture used by a step is captured as failed in the JSON."""
+    pytester.makefile(
+        ".feature",
+        test=textwrap.dedent(
+            """
+    Feature: Failing via pytest.fail in fixture
+        Scenario: Fail in fixture
+            Given a passing step
+            And a step whose fixture fails
+    """
+        ),
+    )
+    pytester.makepyfile(
+        textwrap.dedent(
+            """
+        import pytest
+        from pytest_bdd import given, scenario
+
+        @pytest.fixture
+        def failing_fixture():
+            pytest.fail('fixture failure')
+
+        @given('a passing step')
+        def _():
+            pass
+
+        @given('a step whose fixture fails')
+        def _(failing_fixture):
+            pass
+
+        @scenario('test.feature', 'Fail in fixture')
+        def test_scenario():
+            pass
+    """
+        )
+    )
+    result, jsonobject = runandparse(pytester)
+    result.assert_outcomes(failed=1)
+
+    steps = jsonobject[0]["elements"][0]["steps"]
+    assert steps[0]["result"]["status"] == "passed"
+    assert steps[1]["result"]["status"] == "failed"
+    assert "fixture failure" in steps[1]["result"]["error_message"]


### PR DESCRIPTION
pytest.fail() raises _pytest.outcomes.Failed which inherits from BaseException, not Exception. The except Exception handler in _execute_step_function was bypassing the pytest_bdd_step_error hook, leaving the step's failed flag as False and causing all steps to appear as "passed" in the JSON output even when the test failed.
