### PR TITLE
Fix over-quoting of backslashes in table cells

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,6 +30,7 @@ Removed
 
 Fixed
 +++++
+* Backslashes in datatable and examples table cells are no longer over-quoted. A cell containing a single backslash now reaches the step as a single backslash, matching the Gherkin escaping rules. `#769 <https://github.com/pytest-dev/pytest-bdd/issues/769>`_
 * Made type annotations stronger and removed most of the ``typing.Any`` usages and ``# type: ignore`` annotations. `#658 <https://github.com/pytest-dev/pytest-bdd/pull/658>`_
 
 Security

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,7 +30,7 @@ Removed
 
 Fixed
 +++++
-* Backslashes in datatable and examples table cells are no longer over-quoted. A cell containing a single backslash now reaches the step as a single backslash, matching the Gherkin escaping rules. `#769 <https://github.com/pytest-dev/pytest-bdd/issues/769>`_
+* Backslashes in datatable and examples table cells are no longer over-quoted. A cell containing a single backslash now reaches the step as a single backslash, matching the Gherkin escaping rules. If you compensated by doubling backslashes in feature files, undo that. `#769 <https://github.com/pytest-dev/pytest-bdd/issues/769>`_
 * Made type annotations stronger and removed most of the ``typing.Any`` usages and ``# type: ignore`` annotations. `#658 <https://github.com/pytest-dev/pytest-bdd/pull/658>`_
 * Empty docstrings are now correctly forwarded to step functions as an empty string instead of being silently dropped, which previously caused pytest to report a missing ``docstring`` fixture. `#809 <https://github.com/pytest-dev/pytest-bdd/issues/809>`_
 

--- a/src/pytest_bdd/gherkin_parser.py
+++ b/src/pytest_bdd/gherkin_parser.py
@@ -83,7 +83,7 @@ class Cell:
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> Self:
-        return cls(location=Location.from_dict(data["location"]), value=_to_raw_string(data["value"]))
+        return cls(location=Location.from_dict(data["location"]), value=data["value"])
 
 
 @dataclass
@@ -302,10 +302,6 @@ class GherkinDocument:
             feature=Feature.from_dict(data["feature"]),
             comments=[Comment.from_dict(comment) for comment in data["comments"]],
         )
-
-
-def _to_raw_string(normal_string: str) -> str:
-    return normal_string.replace("\\", "\\\\")
 
 
 def get_gherkin_document(abs_filename: str, encoding: str = "utf-8") -> GherkinDocument:

--- a/tests/datatable/test_datatable.py
+++ b/tests/datatable/test_datatable.py
@@ -214,6 +214,61 @@ def test_steps_with_datatable_missing_argument_in_step(pytester):
     result.assert_outcomes(passed=1)
 
 
+def test_datatable_preserves_backslashes(pytester):
+    """Backslashes in a datatable cell must not be over-quoted (see issue #769).
+
+    Gherkin already resolves cell escaping: "\\\\" is a single backslash, "\\|" is a
+    literal pipe, and a lone backslash stays a single backslash. The cell value must
+    reach the step exactly as the feature author wrote it.
+    """
+    pytester.makefile(
+        ".feature",
+        backslash_datatable=textwrap.dedent(
+            r"""Feature: Backslashes in datatables
+
+              Scenario: Backslashes are not over-quoted
+                Given a datatable with backslashes:
+                  | single | double | escaped_pipe | path          |
+                  | \      | \\     | \|           | C:\Users\John |
+            """
+        ),
+    )
+    pytester.makeconftest(
+        textwrap.dedent(
+            """\
+        from pytest_bdd import given
+        from pytest_bdd.utils import dump_obj
+
+
+        @given("a datatable with backslashes:")
+        def _(datatable):
+            dump_obj(datatable)
+
+    """
+        )
+    )
+    pytester.makepyfile(
+        textwrap.dedent(
+            """\
+        from pytest_bdd import scenario
+
+        @scenario("backslash_datatable.feature", "Backslashes are not over-quoted")
+        def test_backslash_datatable():
+            pass
+        """
+        )
+    )
+
+    result = pytester.runpytest("-s")
+    result.assert_outcomes(passed=1)
+
+    datatable = collect_dumped_objects(result)[0]
+    assert datatable == [
+        ["single", "double", "escaped_pipe", "path"],
+        ["\\", "\\", "|", r"C:\Users\John"],
+    ]
+
+
 def test_datatable_step_argument_is_reserved_and_cannot_be_used(pytester):
     pytester.makefile(
         ".feature",

--- a/tests/feature/test_outline.py
+++ b/tests/feature/test_outline.py
@@ -272,8 +272,9 @@ def test_outline_with_escaped_pipes(pytester):
         r"bork |",
         r"bork||bork",
         r"|",
-        r"bork      \\",
-        r"bork    \\|",
+        # An escaped backslash "\\" in a cell is a single backslash, per the Gherkin spec.
+        "bork      \\",
+        r"bork    \|",
     ]
 
 


### PR DESCRIPTION
Fixes #769

## Problem

Backslashes in datatable and Examples table cells were doubled. A cell written as a single backslash reached the step as two:

```gherkin
Then expect backslash in datatable
  | \ |
```

```python
@then("expect backslash in datatable")
def _(datatable):
    assert datatable[0][0] == "\\"   # failed: value was "\\\\"
```

## Cause

`gherkin_parser.Cell.from_dict` ran every cell value through a helper:

```python
def _to_raw_string(normal_string: str) -> str:
    return normal_string.replace("\\", "\\\\")
```

The `gherkin` library already resolves cell escaping per the Gherkin spec before pytest-bdd sees the value (`\\` -> `\`, `\|` -> `|`, `\n` -> newline, a lone `\` stays `\`). The extra pass doubled every backslash a second time. This looks like the leftover compatibility workaround mentioned in the issue thread.

## Fix

Deliver the cell value exactly as `gherkin` resolves it and drop the now-unused helper (it had a single call site).

## Backwards compatibility

This is a behaviour change, not a pure internal fix. Cells now carry the Gherkin-resolved value with no extra doubling. Anyone who relied on the old doubled output (for example asserting `\\` for a single authored backslash, or writing `C:\\\\Users` to survive the old double pass) will need to drop that workaround. Values now match what the feature author wrote and what other Gherkin implementations produce.

## Tests

- New `tests/datatable/test_datatable.py::test_datatable_preserves_backslashes` covering a lone backslash, an escaped `\\`, an escaped pipe `\|`, and a Windows path `C:\Users\John`. Expected values were checked against the raw `gherkin` parser output.
- Updated the two `test_outline_with_escaped_pipes` expectations that encoded the old doubled output (`bork      \\` now decodes to a single trailing backslash; `bork    \\\|` now decodes to `bork    \|`).
- `CHANGES.rst`: entry under Unreleased / Fixed.

Full suite passes locally except for pre-existing Windows-only path-separator failures in `test_generate` / `test_migrate` / `test_feature_base_dir` that also fail on an unmodified checkout and are unrelated to this change.
