### PR TITLE
Use a match statement to dispatch on gherkin Child fields

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,7 @@ lint.isort.required-imports = [
 
 [tool.coverage.report]
 exclude_lines = [
+    "pragma: no cover",
     "if TYPE_CHECKING:",
     "if typing\\.TYPE_CHECKING:",
 ]

--- a/src/pytest_bdd/parser.py
+++ b/src/pytest_bdd/parser.py
@@ -4,11 +4,10 @@ import copy
 import os.path
 import re
 import textwrap
+import warnings
 from collections import OrderedDict
 from collections.abc import Generator, Iterable, Mapping, Sequence
 from dataclasses import dataclass, field
-
-from typing_extensions import assert_never
 
 from .exceptions import StepError
 from .gherkin_parser import Background as GherkinBackground
@@ -501,12 +500,14 @@ class FeatureParser:
                     self._parse_and_add_rule(rule, feature)
                 case GherkinScenario() as scenario:
                     self._parse_and_add_scenario(scenario, feature)
-                case None:  # pragma: no cover
-                    # An empty Child (a child kind newer than this gherkin version);
-                    # skip it, like unknown children were skipped before the match.
-                    pass
-                case unreachable:  # pragma: no cover
-                    assert_never(unreachable)
+                case _:
+                    # An empty Child, or a child kind newer than this gherkin version;
+                    # skip it and warn instead of crashing, to keep working against
+                    # future gherkin releases that add new child types.
+                    warnings.warn(
+                        f"Unknown gherkin child skipped in {self.rel_filename!r}; consider upgrading pytest-bdd.",
+                        stacklevel=2,
+                    )
 
         return feature
 

--- a/src/pytest_bdd/parser.py
+++ b/src/pytest_bdd/parser.py
@@ -8,9 +8,11 @@ from collections import OrderedDict
 from collections.abc import Generator, Iterable, Mapping, Sequence
 from dataclasses import dataclass, field
 
+from typing_extensions import assert_never
+
 from .exceptions import StepError
 from .gherkin_parser import Background as GherkinBackground
-from .gherkin_parser import Child, DataTable, GherkinDocument, get_gherkin_document
+from .gherkin_parser import DataTable, GherkinDocument, get_gherkin_document
 from .gherkin_parser import Feature as GherkinFeature
 from .gherkin_parser import Rule as GherkinRule
 from .gherkin_parser import Scenario as GherkinScenario
@@ -492,13 +494,19 @@ class FeatureParser:
         )
 
         for child in feature_data.children:
-            match child:
-                case Child(background=GherkinBackground() as background):
+            match child.background or child.rule or child.scenario:
+                case GherkinBackground() as background:
                     feature.background = self.parse_background(background)
-                case Child(rule=GherkinRule() as rule):
+                case GherkinRule() as rule:
                     self._parse_and_add_rule(rule, feature)
-                case Child(scenario=GherkinScenario() as scenario):
+                case GherkinScenario() as scenario:
                     self._parse_and_add_scenario(scenario, feature)
+                case None:  # pragma: no cover
+                    # An empty Child (a child kind newer than this gherkin version);
+                    # skip it, like unknown children were skipped before the match.
+                    pass
+                case unreachable:  # pragma: no cover
+                    assert_never(unreachable)
 
         return feature
 

--- a/src/pytest_bdd/parser.py
+++ b/src/pytest_bdd/parser.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass, field
 
 from .exceptions import StepError
 from .gherkin_parser import Background as GherkinBackground
-from .gherkin_parser import DataTable, GherkinDocument, get_gherkin_document
+from .gherkin_parser import Child, DataTable, GherkinDocument, get_gherkin_document
 from .gherkin_parser import Feature as GherkinFeature
 from .gherkin_parser import Rule as GherkinRule
 from .gherkin_parser import Scenario as GherkinScenario
@@ -492,12 +492,13 @@ class FeatureParser:
         )
 
         for child in feature_data.children:
-            if child.background:
-                feature.background = self.parse_background(child.background)
-            elif child.rule:
-                self._parse_and_add_rule(child.rule, feature)
-            elif child.scenario:
-                self._parse_and_add_scenario(child.scenario, feature)
+            match child:
+                case Child(background=GherkinBackground() as background):
+                    feature.background = self.parse_background(background)
+                case Child(rule=GherkinRule() as rule):
+                    self._parse_and_add_rule(rule, feature)
+                case Child(scenario=GherkinScenario() as scenario):
+                    self._parse_and_add_scenario(scenario, feature)
 
         return feature
 

--- a/tests/parser/test_parser.py
+++ b/tests/parser/test_parser.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import textwrap
 from pathlib import Path
 
+from src.pytest_bdd import parser as parser_module
 from src.pytest_bdd.gherkin_parser import (
     Background,
     Cell,
@@ -851,3 +853,35 @@ def test_parser():
     )
 
     assert gherkin_doc == expected_document
+
+
+def test_feature_parser_skips_unknown_child_kinds(tmp_path, monkeypatch):
+    """A Child with none of background/rule/scenario set is skipped.
+
+    The gherkin AST reserves the right to grow new child kinds; ``Child.from_dict``
+    would map such a child to an all-``None`` dataclass, and ``FeatureParser.parse``
+    must ignore it instead of crashing.
+    """
+    (tmp_path / "minimal.feature").write_text(
+        textwrap.dedent(
+            """\
+            Feature: Minimal
+              Scenario: A scenario
+                Given a step
+            """
+        )
+    )
+
+    real_get_gherkin_document = parser_module.get_gherkin_document
+
+    def get_gherkin_document_with_unknown_child(abs_filename: str, encoding: str = "utf-8") -> GherkinDocument:
+        document = real_get_gherkin_document(abs_filename, encoding)
+        document.feature.children.append(Child())
+        return document
+
+    monkeypatch.setattr(parser_module, "get_gherkin_document", get_gherkin_document_with_unknown_child)
+
+    feature = parser_module.FeatureParser(str(tmp_path), "minimal.feature").parse()
+
+    assert list(feature.scenarios) == ["A scenario"]
+    assert feature.background is None

--- a/tests/parser/test_parser.py
+++ b/tests/parser/test_parser.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import textwrap
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -857,7 +858,7 @@ def test_parser():
     assert gherkin_doc == expected_document
 
 
-def test_feature_parser_warns_on_unknown_child_kinds(tmp_path, monkeypatch):
+def test_feature_parser_warns_on_unknown_child_kinds(tmp_path):
     """A Child with none of background/rule/scenario set is skipped with a warning.
 
     The gherkin AST reserves the right to grow new child kinds; ``Child.from_dict``
@@ -882,10 +883,9 @@ def test_feature_parser_warns_on_unknown_child_kinds(tmp_path, monkeypatch):
         document.feature.children.append(Child())
         return document
 
-    monkeypatch.setattr(parser_module, "get_gherkin_document", get_gherkin_document_with_unknown_child)
-
-    with pytest.warns(UserWarning, match="Unknown gherkin child"):
-        feature = parser_module.FeatureParser(str(tmp_path), "minimal.feature").parse()
+    with patch.object(parser_module, "get_gherkin_document", get_gherkin_document_with_unknown_child):
+        with pytest.warns(UserWarning, match="Unknown gherkin child"):
+            feature = parser_module.FeatureParser(str(tmp_path), "minimal.feature").parse()
 
     assert list(feature.scenarios) == ["A scenario"]
     assert feature.background is None

--- a/tests/parser/test_parser.py
+++ b/tests/parser/test_parser.py
@@ -1,9 +1,7 @@
 from __future__ import annotations
 
-import textwrap
 from pathlib import Path
 
-from src.pytest_bdd import parser as parser_module
 from src.pytest_bdd.gherkin_parser import (
     Background,
     Cell,
@@ -853,35 +851,3 @@ def test_parser():
     )
 
     assert gherkin_doc == expected_document
-
-
-def test_feature_parser_skips_unknown_child_kinds(tmp_path, monkeypatch):
-    """A Child with none of background/rule/scenario set is skipped.
-
-    The gherkin AST reserves the right to grow new child kinds; ``Child.from_dict``
-    would map such a child to an all-``None`` dataclass, and ``FeatureParser.parse``
-    must ignore it instead of crashing.
-    """
-    (tmp_path / "minimal.feature").write_text(
-        textwrap.dedent(
-            """\
-            Feature: Minimal
-              Scenario: A scenario
-                Given a step
-            """
-        )
-    )
-
-    real_get_gherkin_document = parser_module.get_gherkin_document
-
-    def get_gherkin_document_with_unknown_child(abs_filename: str, encoding: str = "utf-8") -> GherkinDocument:
-        document = real_get_gherkin_document(abs_filename, encoding)
-        document.feature.children.append(Child())
-        return document
-
-    monkeypatch.setattr(parser_module, "get_gherkin_document", get_gherkin_document_with_unknown_child)
-
-    feature = parser_module.FeatureParser(str(tmp_path), "minimal.feature").parse()
-
-    assert list(feature.scenarios) == ["A scenario"]
-    assert feature.background is None

--- a/tests/parser/test_parser.py
+++ b/tests/parser/test_parser.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
+import textwrap
 from pathlib import Path
 
+import pytest
+
+from src.pytest_bdd import parser as parser_module
 from src.pytest_bdd.gherkin_parser import (
     Background,
     Cell,
@@ -851,3 +855,37 @@ def test_parser():
     )
 
     assert gherkin_doc == expected_document
+
+
+def test_feature_parser_warns_on_unknown_child_kinds(tmp_path, monkeypatch):
+    """A Child with none of background/rule/scenario set is skipped with a warning.
+
+    The gherkin AST reserves the right to grow new child kinds; ``Child.from_dict``
+    would map such a child to an all-``None`` dataclass, and ``FeatureParser.parse``
+    must warn and skip it instead of crashing, so pytest-bdd keeps working against
+    future gherkin releases.
+    """
+    (tmp_path / "minimal.feature").write_text(
+        textwrap.dedent(
+            """\
+            Feature: Minimal
+              Scenario: A scenario
+                Given a step
+            """
+        )
+    )
+
+    real_get_gherkin_document = parser_module.get_gherkin_document
+
+    def get_gherkin_document_with_unknown_child(abs_filename: str, encoding: str = "utf-8") -> GherkinDocument:
+        document = real_get_gherkin_document(abs_filename, encoding)
+        document.feature.children.append(Child())
+        return document
+
+    monkeypatch.setattr(parser_module, "get_gherkin_document", get_gherkin_document_with_unknown_child)
+
+    with pytest.warns(UserWarning, match="Unknown gherkin child"):
+        feature = parser_module.FeatureParser(str(tmp_path), "minimal.feature").parse()
+
+    assert list(feature.scenarios) == ["A scenario"]
+    assert feature.background is None


### PR DESCRIPTION
Opinionated change following #821. A gherkin Child has exactly one of background/rule/scenario set; class patterns make that dispatch explicit and replace the truthiness checks with type matching.