### PR TITLE
Revert "feat: use scenarios() shortcut in code generation template (#796)"

### DIFF
--- a/src/pytest_bdd/templates/test.py.mak
+++ b/src/pytest_bdd/templates/test.py.mak
@@ -1,22 +1,22 @@
-<%
-    feature_paths = sorted(set(f.rel_filename for f in features))
-%>\
 % if features:
 """${ features[0].name or features[0].rel_filename } feature tests."""
 
 from pytest_bdd import (
     given,
-    scenarios,
+    scenario,
     then,
     when,
 )
 
-% for feature_path in feature_paths:
-scenarios('${feature_path}')
-% endfor
-
 
 % endif
+% for scenario in sorted(scenarios, key=lambda scenario: scenario.name):
+@scenario('${scenario.feature.rel_filename}', ${ make_string_literal(scenario.name)})
+def test_${ make_python_name(scenario.name)}():
+    ${make_python_docstring(scenario.name)}
+
+
+% endfor
 % for step in steps:
 @${step.type}(${ make_string_literal(step.name)})
 def _():

--- a/tests/scripts/test_generate.py
+++ b/tests/scripts/test_generate.py
@@ -42,12 +42,15 @@ def test_generate(pytester, monkeypatch, capsys):
 
     from pytest_bdd import (
         given,
-        scenarios,
+        scenario,
         then,
         when,
     )
 
-    scenarios('scripts/generate.feature')
+
+    @scenario('scripts/generate.feature', 'Given and when using the same fixture should not evaluate it twice')
+    def test_given_and_when_using_the_same_fixture_should_not_evaluate_it_twice():
+        """Given and when using the same fixture should not evaluate it twice."""
 
 
     @given('1 have a fixture (appends 1 to a list) in reuse syntax')
@@ -105,12 +108,15 @@ def test_generate_with_quotes(pytester):
 
     from pytest_bdd import (
         given,
-        scenarios,
+        scenario,
         then,
         when,
     )
 
-    scenarios('generate_with_quotes.feature')
+
+    @scenario('generate_with_quotes.feature', 'A step definition with quotes should be escaped as needed')
+    def test_a_step_definition_with_quotes_should_be_escaped_as_needed():
+        """A step definition with quotes should be escaped as needed."""
 
 
     @given('I have a fixture with "double" quotes')
@@ -178,12 +184,15 @@ def test_unicode_characters(pytester, monkeypatch):
 
             from pytest_bdd import (
                 given,
-                scenarios,
+                scenario,
                 then,
                 when,
             )
 
-            scenarios('unicode_characters.feature')
+
+            @scenario('unicode_characters.feature', 'Calculating the circumference of a circle')
+            def test_calculating_the_circumference_of_a_circle():
+                """Calculating the circumference of a circle."""
 
 
             @given('We have a circle')


### PR DESCRIPTION
Reverts #796 as requested in https://github.com/pytest-dev/pytest-bdd/pull/796#issuecomment-4887010098 — it was merged before @youtux's review comments were addressed.

A follow-up PR re-applying the change with the review comments addressed comes next.